### PR TITLE
Update plex.json

### DIFF
--- a/docs/public/install-scripts/plex.json
+++ b/docs/public/install-scripts/plex.json
@@ -6,7 +6,8 @@
       "description": "The claim token for the server to obtain a real server token. If not provided, server is will not be automatically logged in. If server is already logged in, this parameter is ignored. You can obtain a claim token to login your server to your plex account by visiting https://www.plex.tv/claim.",
       "type": "text",
       "key": "plex_claim_token",
-      "required": false
+      "required": false,
+      "default": ""
     }
   ],
   "ensure_directories_exists": [


### PR DESCRIPTION
Thanks to Josh for catching this:

"... I spotted a small issue in the curated Plex installer. The claim token question is not marked as required but lacks a "default" value. Skipping the question causes the macro $QUESTION(plex_claim_token) to fail with “Install script requires a response.” Adding "default": "" fixes it as the macro can resolve to an empty string."