### PR TITLE
Removes pm2 process management for docs

### DIFF
--- a/.github/workflows/dev.js.yml
+++ b/.github/workflows/dev.js.yml
@@ -23,6 +23,3 @@ jobs:
         submodules: 'recursive'
     - run: npm ci
     - run: npm run docs:build
-    - run: pm2 stop docs || true
-    - run: pm2 serve docs/.vitepress/dist 4173 --name "docs" --spa
-


### PR DESCRIPTION
Removes pm2 stop and serve commands from the docs build process. This simplifies the deployment workflow for the documentation site.