### PR TITLE
Adds release notes for hotfix 2025-12-30

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -139,6 +139,7 @@ const sidebar: DefaultTheme.SidebarItem[] = [
     collapsed: true,
     items: [
       // auto-generated-release-notes-start
+            { text: '2025-12-30', link: '/release-notes/command-deck/2025-12-30' },
             { text: '2025-12-28', link: '/release-notes/command-deck/2025-12-28' },
             { text: '2025-12-26', link: '/release-notes/command-deck/2025-12-26' },
             { text: '2025-11-25', link: '/release-notes/command-deck/2025-11-25' },

--- a/docs/release-notes/command-deck/2025-12-30.md
+++ b/docs/release-notes/command-deck/2025-12-30.md
@@ -1,0 +1,13 @@
+# December 30, 2025 - Hotfix : App Configuration Updates
+
+Following user feedback, we've removed the "updated script available" notification and improved how app configuration updates work.
+
+## Enhancements
+
+### Updated Configuration Workflow
+
+Configuration updates now expand under the Options dialog for manual application. When we introduce updated curations with new functionality like automatic GPU detection, you can take advantage of these improvements on your own timeline.
+
+The reset|update action now always shows a confirmation dialog with improved messaging.
+
+**NOTE:** This update was applied automatically to your Command Deck. You may need to clear your cache. Help with clearing your cache is available [here](/troubleshooting/common-issues/ClearCache).

--- a/docs/release-notes/command-deck/index.md
+++ b/docs/release-notes/command-deck/index.md
@@ -11,6 +11,7 @@ For users who are actively connected during an update, there may be a brief down
 <!-- auto-generated-year-sections-start -->
 ## 2025 Releases
 
+- [**2025-12-30**](./2025-12-30) - Hotfix : App Configuration Updates
 - [**2025-12-28**](./2025-12-28) - Hotfix : Apps Overhaul
 - [**2025-12-26**](./2025-12-26) - Apps Overhaul, 2FA, GPU Detection, Goldeye Compatibility
 - [**2025-11-25**](./2025-11-25) - New Apps Sonarr, Radarr and Prowlarr


### PR DESCRIPTION
Adds release notes for the December 30, 2025 hotfix addressing user feedback on app configuration updates and the removal of the "updated script available" notification.