### PR TITLE
feat(script): add gramps

### DIFF
--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -6,6 +6,7 @@
 | `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.3 KB | 2025-12-25 |
 | `drawio` | [drawio.json](/install-scripts/drawio.json) | 739 B | 2025-12-25 |
 | `emby` | [emby.json](/install-scripts/emby.json) | 2.2 KB | 2026-01-21 |
+| `gramps` | [gramps.json](/install-scripts/gramps.json) | 2.1 KB | 2026-01-28 |
 | `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.8 KB | 2025-12-25 |
 | `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.6 KB | 2025-12-04 |
 | `immich` | [immich.json](/install-scripts/immich.json) | 1.7 KB | 2025-12-12 |

--- a/docs/public/install-scripts/gramps.json
+++ b/docs/public/install-scripts/gramps.json
@@ -1,0 +1,66 @@
+{
+  "version": 3,
+  "script": {
+    "version": "1.0.0",
+    "changeLog": "Initial Script"
+  },
+  "requirements": {
+    "locations": ["ApplicationsPerformance", "ApplicationsCapacity"],
+    "specifications": ["2CORE", "4096MB"],
+    "permissions": ["READ_WRITE_LOCATIONS"],
+    "ports": []
+  },
+  "installation_questions": [
+    {
+      "question": "Disable Anonymous Telemetry",
+      "description": "Disable anonymous telemetry for Gramps Web. This will prevent Gramps Web from sending anonymous statistics data to the Gramps project.",
+      "type": "boolean",
+      "key": "disable_telemetry",
+      "required": false,
+      "default": false
+    }
+  ],
+  "ensure_directories_exists": [
+    {
+      "path": "$LOCATION(ApplicationsPerformance)",
+      "network_share": true
+    },
+    "$LOCATION(ApplicationsPerformance)/gramps/users",
+    "$LOCATION(ApplicationsPerformance)/gramps/index",
+    "$LOCATION(ApplicationsPerformance)/gramps/thumbnail_cache",
+    "$LOCATION(ApplicationsPerformance)/gramps/cache",
+    "$LOCATION(ApplicationsPerformance)/gramps/grampsdb",
+    {
+      "path": "$LOCATION(ApplicationsCapacity)",
+      "network_share": true
+    },
+    "$LOCATION(ApplicationsCapacity)/gramps/media"
+  ],
+  "app_values": {
+    "gramps": {
+      "redis_password": "$RANDOM_STRING(16)",
+      "disable_telemetry": "$QUESTION(disable_telemetry)",
+      "app_key": "$RANDOM_STRING(32)"
+    },
+    "storage": {
+      "users": "$HOST_PATH($LOCATION(ApplicationsPerformance)/gramps/users)",
+      "index": "$HOST_PATH($LOCATION(ApplicationsPerformance)/gramps/index)",
+      "thumbnail_cache": "$HOST_PATH($LOCATION(ApplicationsPerformance)/gramps/thumbnail_cache)",
+      "cache": "$HOST_PATH($LOCATION(ApplicationsPerformance)/gramps/cache)",
+      "grampsdb": "$HOST_PATH($LOCATION(ApplicationsPerformance)/gramps/grampsdb)",
+      "media": "$HOST_PATH($LOCATION(ApplicationsCapacity)/gramps/media)"
+    },
+    "network": {
+      "web_port": {
+        "bind_mode": "published",
+        "port_number": 30179
+      }
+    },
+    "resources": {
+      "limits": {
+        "cpus": 2,
+        "memory": "$MEMORY(10%, 4096)"
+      }
+    }
+  }
+}


### PR DESCRIPTION
During testing the datasets were created correctly, but the install of the app itself failed.
Finishing up the install through the TrueNAS catalogue directly, mapping all created datasets manually, worked like a charm.

Currently, I don't believe this to be an issue with the script, but something else in hexos. I have sent in a bug report through the "Give us feedback" form in the Deck interface.