### PR TITLE
Adds release notes for January 21, 2026

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -139,6 +139,7 @@ const sidebar: DefaultTheme.SidebarItem[] = [
     collapsed: true,
     items: [
       // auto-generated-release-notes-start
+            { text: '2026-01-21', link: '/release-notes/command-deck/2026-01-21' },
             { text: '2026-01-13', link: '/release-notes/command-deck/2026-01-13' },
             { text: '2026-01-08', link: '/release-notes/command-deck/2026-01-08' },
             { text: '2025-12-30', link: '/release-notes/command-deck/2025-12-30' },

--- a/docs/release-notes/command-deck/2026-01-21.md
+++ b/docs/release-notes/command-deck/2026-01-21.md
@@ -1,0 +1,20 @@
+# January 21, 2026 - Mobile Dialogs, App Lifecycle, HexOS Local Prep
+
+This release introduces improved app lifecycle management, mobile-optimized dialogs, and lays the groundwork for HexOS Local.
+
+## Enhancements
+
+### App Lifecycle Management
+
+App start and stop operations are now individually orchestrated, providing better progress tracking and improved update workflows. App cards display server messages directly from TrueNAS, surfacing any startup configuration issues or lifecycle problems immediately for faster troubleshooting.
+
+### Mobile-Optimized Dialogs
+
+We're testing a new dialog on mobile to give better accessibility and reach. These appear as traditional modals on desktop and slide-up drawers on mobile. These have been applied to folders, users, and network settings.
+
+### HexOS Local Preparation
+
+This release also pushes a large block of code behind the scenes that will support the coming soon [HexOS Local](https://docs.hexos.com/blog/2025-11-25.html)
+
+
+**NOTE:** This update was applied automatically to your Command Deck. You may need to clear your cache. Help with clearing your cache is available [here](/troubleshooting/common-issues/ClearCache).

--- a/docs/release-notes/command-deck/index.md
+++ b/docs/release-notes/command-deck/index.md
@@ -11,6 +11,7 @@ For users who are actively connected during an update, there may be a brief down
 <!-- auto-generated-year-sections-start -->
 ## 2026 Releases
 
+- [**2026-01-21**](./2026-01-21) - Mobile Dialogs, App Lifecycle, HexOS Local Prep
 - [**2026-01-13**](./2026-01-13) - UI Improvements & Goldeye System Updates
 - [**2026-01-08**](./2026-01-08) - HexOS Curated Apps & Enhanced Diagnostics
 


### PR DESCRIPTION
Adds the release notes for January 21, 2026, which includes information about mobile dialogs, app lifecycle management improvements, and preparations for HexOS Local.