### PR TITLE
scrutiny script ensure directory fix for main

### DIFF
--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -5,11 +5,11 @@
 |---|---|---:|---|
 | `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.3 KB | 2025-12-25 |
 | `drawio` | [drawio.json](/install-scripts/drawio.json) | 739 B | 2025-12-25 |
-| `emby` | [emby.json](/install-scripts/emby.json) | 2.2 KB | 2026-01-06 |
+| `emby` | [emby.json](/install-scripts/emby.json) | 2.2 KB | 2026-01-21 |
 | `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.8 KB | 2025-12-25 |
 | `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.6 KB | 2025-12-04 |
 | `immich` | [immich.json](/install-scripts/immich.json) | 1.7 KB | 2025-12-12 |
-| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.2 KB | 2025-12-12 |
+| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.2 KB | 2026-01-21 |
 | `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.3 KB | 2025-12-25 |
 | `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.4 KB | 2025-12-28 |
 | `peanut` | [peanut.json](/install-scripts/peanut.json) | 823 B | 2025-12-25 |
@@ -17,7 +17,7 @@
 | `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 766 B | 2025-12-04 |
 | `qbittorrent` | [qbittorrent.json](/install-scripts/qbittorrent.json) | 1.0 KB | 2025-12-04 |
 | `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.2 KB | 2025-12-04 |
-| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.2 KB | 2025-12-25 |
+| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.3 KB | 2025-12-25 |
 | `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.2 KB | 2025-12-04 |
 | `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.0 KB | 2025-12-25 |
 <!-- curated:index:end -->

--- a/docs/public/install-scripts/scrutiny.json
+++ b/docs/public/install-scripts/scrutiny.json
@@ -18,6 +18,10 @@
     "ports": []
   },
   "ensure_directories_exists": [
+    {
+      "path": "$LOCATION(ApplicationsPerformance)",
+      "network_share": true
+    },
     "$LOCATION(ApplicationsPerformance)/scrutiny/config",
     "$LOCATION(ApplicationsPerformance)/scrutiny/influxdb"
   ],


### PR DESCRIPTION
this is the updated scrutiny install script that adds the ensure directory that was missing.