### PR TITLE
feat(script): add tailscale

### DIFF
--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -20,5 +20,5 @@
 | `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.3 KB | 2026-03-15 |
 | `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.2 KB | 2025-12-04 |
 | `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.1 KB | 2026-03-15 |
-| `tailscale` | [tailscale.json](/install-scripts/tailscale.json) | 1.8 KB | 2026-02-07 |
+| `tailscale` | [tailscale.json](/install-scripts/tailscale.json) | 1.8 KB | 2026-04-02 |
 <!-- curated:index:end -->

--- a/docs/public/install-scripts/tailscale.json
+++ b/docs/public/install-scripts/tailscale.json
@@ -1,13 +1,14 @@
 {
   "version": 3,
   "script": {
-    "version": "1.0.0",
-    "changeLog": "Initial Script"
+    "version": "1.0.1",
+    "changeLog": "Updated requirements"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance"],
     "specifications": ["2CORE", "200MB"],
-    "permissions": ["READ_WRITE_LOCATIONS"]
+    "permissions": ["READ_WRITE_LOCATIONS"],
+    "ports": []
   },
   "installation_questions": [
     {


### PR DESCRIPTION
Introduce a new installation script for Tailscale, including configuration options and requirements. Update documentation to reflect the addition.

This is based on the Custom Install Script found at https://hub.hexos.com/topic/4267-trial-tailscale-custom-install/.

I've editted and validated the install script against the [TrueNAS app schema](https://github.com/truenas/apps/blob/master/trains/community/tailscale/app_versions.json).

The following changes were made to the version from the forum:
- Removed default values for questions.
- Used the TrueNAS app schema descriptions in the `installation_questions` descriptions.
- Added application state directory to `ensure_directories_exists`.
- Added `accept_routes` to `app_values` with the default value from the truenas app schema.
- Reduced resource limits after observing the app running.