### PR TITLE
Draft March 2026 Command Deck Release Notes

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -148,6 +148,7 @@ const sidebar: DefaultTheme.SidebarItem[] = [
     collapsed: true,
     items: [
       // auto-generated-release-notes-start
+            { text: '2026-03-23', link: '/release-notes/command-deck/2026-03-23' },
             { text: '2026-01-21', link: '/release-notes/command-deck/2026-01-21' },
             { text: '2026-01-13', link: '/release-notes/command-deck/2026-01-13' },
             { text: '2026-01-08', link: '/release-notes/command-deck/2026-01-08' },

--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -3,21 +3,21 @@
 <!-- curated:index:start -->
 | App | Download | Size | Last Modified |
 |---|---|---:|---|
-| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.3 KB | 2025-12-25 |
-| `drawio` | [drawio.json](/install-scripts/drawio.json) | 757 B | 2025-12-25 |
-| `emby` | [emby.json](/install-scripts/emby.json) | 2.2 KB | 2026-01-21 |
-| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.8 KB | 2025-12-25 |
-| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.6 KB | 2025-12-04 |
-| `immich` | [immich.json](/install-scripts/immich.json) | 1.7 KB | 2025-12-12 |
-| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.2 KB | 2026-01-21 |
-| `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.4 KB | 2025-12-25 |
-| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.5 KB | 2025-12-28 |
-| `peanut` | [peanut.json](/install-scripts/peanut.json) | 834 B | 2025-12-25 |
+| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.3 KB | 2026-03-15 |
+| `drawio` | [drawio.json](/install-scripts/drawio.json) | 757 B | 2026-03-15 |
+| `emby` | [emby.json](/install-scripts/emby.json) | 2.2 KB | 2026-03-15 |
+| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.8 KB | 2026-03-15 |
+| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.6 KB | 2026-03-19 |
+| `immich` | [immich.json](/install-scripts/immich.json) | 1.7 KB | 2026-03-15 |
+| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.2 KB | 2026-03-15 |
+| `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.4 KB | 2026-03-15 |
+| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.5 KB | 2026-03-15 |
+| `peanut` | [peanut.json](/install-scripts/peanut.json) | 834 B | 2026-03-15 |
 | `plex` | [plex.json](/install-scripts/plex.json) | 3.4 KB | 2025-12-12 |
 | `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 766 B | 2025-12-04 |
 | `qbittorrent` | [qbittorrent.json](/install-scripts/qbittorrent.json) | 1.0 KB | 2025-12-04 |
 | `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.2 KB | 2025-12-04 |
-| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.3 KB | 2026-01-31 |
+| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.3 KB | 2026-03-15 |
 | `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.2 KB | 2025-12-04 |
-| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.1 KB | 2025-12-25 |
+| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.1 KB | 2026-03-15 |
 <!-- curated:index:end -->

--- a/docs/release-notes/command-deck/2026-02-placeholder.md
+++ b/docs/release-notes/command-deck/2026-02-placeholder.md
@@ -1,8 +1,0 @@
-# February , 2026 - Placeholder with community credit
-
-
-
-### Special Thanks to the the following members of our community
-
-- [AeroXuk](https://hub.hexos.com/profile/494-aeroxuk/) - For reporting and determining the cause of a bug with an install script.
-- [SimJoSt](https://hub.hexos.com/profile/20928-simjost/) - For creating installation scripts for [Gramps](https://www.grampsweb.org/) & [FileBrowser Quantum](https://filebrowserquantum.com) and implementing AeroXuk's bugfix.

--- a/docs/release-notes/command-deck/2026-03-23.md
+++ b/docs/release-notes/command-deck/2026-03-23.md
@@ -1,0 +1,41 @@
+# March 23, 2026 - Local Foundations & UI Polish
+
+This release delivers 100s of commits for polish on the UI across the dashboard, app catalog, and storage views, along with infrastructure work for the upcoming Local release.
+
+### Local Foundations
+As part of a significant infrastructure effort behind the scenes for [HexOS Local](https://docs.hexos.com/blog/2025-11-25.html), we've added support in preparation for migration to the upcoming Local release. When users begin incrementally migrating to the new architecture, they will be prompted how to transition clearly.
+
+
+### General Polish
+- **Dashboard** rebuilt with new system cards for activity, memory, processor, and network interfaces — each with dedicated detail views and resource usage charts
+- **App Catalog** reworked with featured cards, empty states, improved app detail pages, and more reliable app icons
+- **Storage** pool drives page overhauled with new pool cards, detail views, and network interface speeds on interface cards
+- **Forms** redesigned with new inputs and checkboxes for a more consistent experience
+
+### Misc
+- Sticky header support with responsive design improvements
+- Improved sheets, drawers, and dialogs
+- New color tokens for status indicators in dark mode
+- Loading skeletons across system cards
+- Title truncation on catalog cards
+- Improved active link highlighting on navigation menus
+
+### Bug Fixes
+- Fixed form issues with the user create/edit dialog
+- Fixed routing issues on app menus
+- Fixed invisible loading indicators in dark mode
+- Fixed button styling on app update and upgrade prompts
+- Fixed drive replace button on drive details
+- Fixed button alignment on server unavailable screen
+- Fixed disabled state on the create pool button
+- Fixed cache indicator on the memory widget
+- Fixed update alert styles
+
+### Special Thanks to the the following members of our community
+- [Anna Morris](https://gingerling.co.uk) - For helping with documentation, guides and general feedback.  
+- [AeroXuk](https://hub.hexos.com/profile/494-aeroxuk/) - For reporting and determining the cause of a bug with an install script.
+- [SimJoSt](https://hub.hexos.com/profile/20928-simjost/) - For creating installation scripts for [Gramps](https://www.grampsweb.org/) & [FileBrowser Quantum](https://filebrowserquantum.com) and implementing AeroXuk's bugfix.
+- [rhjanssen](https://github.com/rhjanssen) - For exploring installation scripts for [OpenCloud](https://opencloud.eu/), [OnlyOffice Document Server](https://www.onlyoffice.com/) & [Collabora Online](https://www.collaboraoffice.com/).
+
+
+**NOTE:** This update was applied automatically to your Command Deck. You may need to clear your cache. Help with clearing your cache is available [here](/troubleshooting/common-issues/ClearCache).

--- a/docs/release-notes/command-deck/index.md
+++ b/docs/release-notes/command-deck/index.md
@@ -11,6 +11,7 @@ For users who are actively connected during an update, there may be a brief down
 <!-- auto-generated-year-sections-start -->
 ## 2026 Releases
 
+- [**2026-03-23**](./2026-03-23) - Local Foundations & UI Polish
 - [**2026-01-21**](./2026-01-21) - Mobile Dialogs, App Lifecycle, Polish, HexOS Local Prep
 - [**2026-01-13**](./2026-01-13) - UI Improvements & Goldeye System Updates
 - [**2026-01-08**](./2026-01-08) - HexOS Curated Apps & Enhanced Diagnostics


### PR DESCRIPTION
- Added release notes for Command Deck covering UI polish and Local migration foundations.
- Updated the "Last Modified" dates for several curated app install scripts.
- Removed the February 2026 placeholder release notes.