### PR TITLE
Adds 2026-03-27 Hotfix Release Notes

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -148,6 +148,7 @@ const sidebar: DefaultTheme.SidebarItem[] = [
     collapsed: true,
     items: [
       // auto-generated-release-notes-start
+            { text: '2026-03-27', link: '/release-notes/command-deck/2026-03-27' },
             { text: '2026-03-24', link: '/release-notes/command-deck/2026-03-24' },
             { text: '2026-01-21', link: '/release-notes/command-deck/2026-01-21' },
             { text: '2026-01-13', link: '/release-notes/command-deck/2026-01-13' },

--- a/docs/release-notes/command-deck/2026-03-27.md
+++ b/docs/release-notes/command-deck/2026-03-27.md
@@ -1,0 +1,7 @@
+# March 27, 2026 - Hotfix : Apps Newly Curated
+
+This hotfix addresses:
+- Newly Curated app section card details will link to the correct app detail for all cases.
+- Installation buttons will correctly link to the appropiate actions now even when there are inconsistencies between TrueNAS's app catalog appId and appName.
+- Resolved an issue on certain viewport widths where apps would not wrap properly when a significant number are installed. 
+- A race condition was causing some App Icons to not display properly for some users on first load.

--- a/docs/release-notes/command-deck/index.md
+++ b/docs/release-notes/command-deck/index.md
@@ -11,6 +11,7 @@ For users who are actively connected during an update, there may be a brief down
 <!-- auto-generated-year-sections-start -->
 ## 2026 Releases
 
+- [**2026-03-27**](./2026-03-27) - Hotfix : Apps Newly Curated
 - [**2026-03-24**](./2026-03-24) - Local Foundations & UI Polish
 - [**2026-01-21**](./2026-01-21) - Mobile Dialogs, App Lifecycle, Polish, HexOS Local Prep
 - [**2026-01-13**](./2026-01-13) - UI Improvements & Goldeye System Updates


### PR DESCRIPTION
Adds documentation for the March 27, 2026 hotfix release, which addresses several issues within the "Apps Newly Curated" section.

This hotfix:
- Ensures app detail cards link to the correct application details.
- Corrects installation buttons to function properly, even with inconsistencies between app catalog IDs and names.
- Resolves app wrapping issues on various viewport widths.
- Fixes a race condition that prevented some app icons from displaying on initial load.

Updates the navigation sidebar and the main release notes index to include this new entry.