### PR TITLE
Add release notes landing page and update sidebar navigation

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -145,9 +145,14 @@ const sidebar: DefaultTheme.SidebarItem[] = [
   },
   {
     text: 'Release Notes',
-    link: '/release-notes/command-deck/',
+    link: '/release-notes/',
     collapsed: true,
     items: [
+      {
+        text: 'Command Deck',
+        link: '/release-notes/command-deck/',
+        collapsed: true,
+        items: [
       // auto-generated-release-notes-start
             { text: '2026-03-27', link: '/release-notes/command-deck/2026-03-27' },
             { text: '2026-03-24', link: '/release-notes/command-deck/2026-03-24' },
@@ -171,6 +176,8 @@ const sidebar: DefaultTheme.SidebarItem[] = [
             { text: '2025-01-08', link: '/release-notes/command-deck/2025-01-08' },
             { text: '2024-11-29', link: '/release-notes/command-deck/2024-11-29' },
             // auto-generated-release-notes-end
+        ]
+      },
     ]
   },
   {

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+Stay up to date with the latest changes to HexOS and the underlying TrueNAS platform.
+
+## HexOS Command Deck
+
+The Command Deck is the HexOS web interface. Updates are automatically deployed — no action needed on your part.
+
+**[View Command Deck Release Notes →](/release-notes/command-deck/)**
+
+**Latest:** [2026-03-27 — Hotfix : Apps Newly Curated](/release-notes/command-deck/2026-03-27)
+
+## TrueNAS
+
+HexOS is built on TrueNAS. You will be prompted to update as future compatibility with TrueNAS becomes available.
+
+**[View TrueNAS Version Notes →](https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/)**
+
+| Train | Version | TrueNAS Docs |
+|-------|---------|-------------|
+| Goldeye | 25.10 | [Version Notes](https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/) |
+| Fangtooth | 25.04 | [Version Notes](https://www.truenas.com/docs/scale/25.04/gettingstarted/versionnotes/) |
+| Electric Eel | 24.10 | [Version Notes](https://www.truenas.com/docs/scale/24.10/gettingstarted/versionnotes/) |

--- a/scripts/generateReleaseNotesIndex.mjs
+++ b/scripts/generateReleaseNotesIndex.mjs
@@ -8,6 +8,7 @@ const DOCS_DIR = process.env.DOCS_DIR || 'docs'
 
 const RELEASE_NOTES_DIR = path.resolve(__dirname, '..', DOCS_DIR, 'release-notes/command-deck')
 const INDEX_MD = path.resolve(RELEASE_NOTES_DIR, 'index.md')
+const RELEASE_NOTES_LANDING = path.resolve(__dirname, '..', DOCS_DIR, 'release-notes/index.md')
 const SIDEBAR_TS = path.resolve(__dirname, '..', DOCS_DIR, '.vitepress/sidebar.ts')
 
 // Sidebar automation markers
@@ -229,5 +230,52 @@ function updateSidebar() {
   }
 }
 
+function updateLandingPage(releases) {
+  // Sort descending, pick the latest
+  releases.sort((a, b) => b.sortDate - a.sortDate)
+  const latest = releases[0]
+
+  const latestLine = latest
+    ? `**Latest:** [${latest.formattedDate} — ${latest.description}](/release-notes/command-deck/${latest.filename})`
+    : ''
+
+  const content = `# Release Notes
+
+Stay up to date with the latest changes to HexOS and the underlying TrueNAS platform.
+
+## HexOS Command Deck
+
+The Command Deck is the HexOS web interface. Updates are automatically deployed — no action needed on your part.
+
+**[View Command Deck Release Notes →](/release-notes/command-deck/)**
+
+${latestLine}
+
+## TrueNAS
+
+HexOS is built on TrueNAS. You will be prompted to update as future compatibility with TrueNAS becomes available.
+
+**[View TrueNAS Version Notes →](https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/)**
+
+| Train | Version | TrueNAS Docs |
+|-------|---------|-------------|
+| Goldeye | 25.10 | [Version Notes](https://www.truenas.com/docs/scale/25.10/gettingstarted/versionnotes/) |
+| Fangtooth | 25.04 | [Version Notes](https://www.truenas.com/docs/scale/25.04/gettingstarted/versionnotes/) |
+| Electric Eel | 24.10 | [Version Notes](https://www.truenas.com/docs/scale/24.10/gettingstarted/versionnotes/) |
+`
+
+  fs.writeFileSync(RELEASE_NOTES_LANDING, content)
+  console.log('Wrote', RELEASE_NOTES_LANDING)
+}
+
+// Get all releases once, share across functions
+const allFiles = fs.readdirSync(RELEASE_NOTES_DIR)
+  .filter(f => f.endsWith('.md') && f !== 'index.md' && f.match(/^\d{4}-\d{2}-\d{2}\.md$/))
+
+const allReleases = allFiles
+  .map(f => parseReleaseNote(path.join(RELEASE_NOTES_DIR, f)))
+  .filter(r => r !== null)
+
 updateIndexPage()
 updateSidebar()
+updateLandingPage(allReleases)


### PR DESCRIPTION
Creates a central landing page for release notes that provides context for both HexOS Command Deck updates and TrueNAS version links. The sidebar is updated to nest specific release notes under this new landing page, and the automation script now dynamically updates the "Latest" release link on the landing page.
