### PR TITLE
Update community links and references from HexOS Hub to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ docs/
 ## Get Help
 
 - **Found a bug in the docs?** [Open an issue](https://github.com/Eshtek/hexos-docs/issues)
-- **Need help with HexOS?** Visit the [HexOS Community](https://hub.hexos.com/) or contact support directly at support@hexos.com
+- **Need help with HexOS?** Visit the [HexOS Community](https://discord.gg/fCW2htvYdz) or contact support directly at support@hexos.com

--- a/docs/articles/selectingDrives.md
+++ b/docs/articles/selectingDrives.md
@@ -48,4 +48,4 @@ If you start with HDDs and add SSDs later, there will be a migration process to 
 
 ## Need More Help?
 
-If you have more questions regarding storage and drives, please consider [posting in our forums!](https://hub.hexos.com/)
+If you have more questions regarding storage and drives, please consider [posting in our Discord!](https://discord.gg/fCW2htvYdz)

--- a/docs/blog/2025-12-26.md
+++ b/docs/blog/2025-12-26.md
@@ -49,7 +49,7 @@ Each of these apps has been carefully curated with optimized configurations to w
 
 One of the most exciting features in this release is automatic GPU detection and configuration. HexOS now intelligently identifies available GPU resources and automatically attaches them to applications that can benefit from hardware acceleration and transcoding.
 
-This means apps like Plex and Jellyfin can immediately take advantage of your GPU for smooth, efficient media transcoding without manual configuration. We're eager to hear your experiences with this feature, so please share your feedback in the [forums](https://hub.hexos.com).
+This means apps like Plex and Jellyfin can immediately take advantage of your GPU for smooth, efficient media transcoding without manual configuration. We're eager to hear your experiences with this feature, so please share your feedback in the [Discord](https://discord.gg/fCW2htvYdz).
 
 ## Smarter Curation Management
 
@@ -89,7 +89,7 @@ The new Apps platform is available now. Here's what we'd love you to do:
 
 **Install a GPU-accelerated app** like Plex or Jellyfin and experience automatic hardware acceleration. Let us know how it performs.
 
-**Share your feedback** with us in the forums at [hub.hexos.com](https://hub.hexos.com). Your input directly shapes the future of HexOS.
+**Share your feedback** with us in our [Discord](https://discord.gg/fCW2htvYdz). Your input directly shapes the future of HexOS.
 
 **Take advantage of our Holiday Sale** before it ends on December 31st. It's the perfect time to expand your HexOS capabilities. [**HexOS lifetime license**](https://hexos.com/#earlyaccess)
 

--- a/docs/community/community-guides/ImmichMigrationMove.md
+++ b/docs/community/community-guides/ImmichMigrationMove.md
@@ -1,6 +1,6 @@
 # Migrating Immich to New Storage Configuration (Move Method)
 
-*by [@G-M0N3Y-2503](https://hub.hexos.com/profile/29328-g-m0n3y-2503/)*
+*by @G-M0N3Y-2503*
 
 Just adding what I did to get it working for me. However, I received numerous permission warnings for the moves, but they didn't seem to have any ill effect.
 
@@ -8,7 +8,7 @@ My overall plan was to migrate from the old to the new, where the new is how I a
 
 :::info Permission Errors During Migration
 You may see multiple permission denial errors per dataset during the move operations. They occur because ZFS dataset metadata and snapshot attributes cannot be moved with standard `mv` commands. As long as your actual data (photos, videos, etc.) moves successfully, these errors are harmless. The empty datasets can be cleaned up in step 7 after verifying everything works.  
-*edit by [csmanel](https://hub.hexos.com/profile/27801-csmanel/)*  
+*edit by csmanel*  
 :::
 
 ## Storage Layout

--- a/docs/community/community-guides/ImmichMigrationRsync.md
+++ b/docs/community/community-guides/ImmichMigrationRsync.md
@@ -1,6 +1,6 @@
 # Migrating Immich to New Storage Configuration (Rsync Method)
 
-*by [@forsaken](https://hub.hexos.com/profile/17319-forsaken/)*
+*by @forsaken*
 
 I fixed it! 😁, but it was a pain to do it because rsync and TrueNAS dataset that have ACL don't like each other.
 

--- a/docs/community/community-guides/ReplicatingVirtualMachines.md
+++ b/docs/community/community-guides/ReplicatingVirtualMachines.md
@@ -1,6 +1,6 @@
 # Replicating Virtual Machines from one TrueNAS Server to Another
 
-*by [@ShinobiRen](https://hub.hexos.com/profile/27485-shinobiren/?wr=eyJhcHAiOiJmb3J1bXMiLCJtb2R1bGUiOiJmb3J1bXMtY29tbWVudCIsImlkXzEiOjMwNjMsImlkXzIiOjE4MTk2fQ==)*
+*by @ShinobiRen*
 
 Hello everyone!
 

--- a/docs/community/community-guides/SettingUpTailscale.md
+++ b/docs/community/community-guides/SettingUpTailscale.md
@@ -1,6 +1,6 @@
 # Setting Up Tailscale
 
-*by [@speedking456](https://hub.hexos.com/profile/7605-speedking456/?wr=eyJhcHAiOiJmb3J1bXMiLCJtb2R1bGUiOiJmb3J1bXMtY29tbWVudCIsImlkXzEiOjU1MCwiaWRfMiI6Mjk2NX0=)*
+*by @speedking456*
 
 As a fellow Tailscale enjoyer, this was my first thought when I heard about HexOS, "But does it support Tailscale?" and I can confirm it does!
 

--- a/docs/community/how-to-contribute/index.md
+++ b/docs/community/how-to-contribute/index.md
@@ -145,4 +145,4 @@ PullPreview can take a minute or two to build. Be patient! If it's taking longer
 
 ## Need Help?
 
-If you have any questions or need assistance, be sure to check out the [HexOS Community forums](https://hub.hexos.com/) where you can get help from other contributors and the HexOS team.
+If you have any questions or need assistance, be sure to check out the [HexOS Community Discord](https://discord.gg/fCW2htvYdz) where you can get help from other contributors and the HexOS team.

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -26,7 +26,7 @@ Learn more about how to contribute to the docs repository [here](/community/how-
 
 Build our community by helping others:
 
-- Answer questions on the [HexOS Community](https://hub.hexos.com/)
+- Answer questions on the [HexOS Community](https://discord.gg/fCW2htvYdz)
 - Share working configurations
 - Help debug issues
 - Welcome newcomers
@@ -34,7 +34,7 @@ Build our community by helping others:
 ## Getting Started
 
 New to contributing? Start small:
-1. Join the [HexOS Community](https://hub.hexos.com/)
+1. Join the [HexOS Community](https://discord.gg/fCW2htvYdz)
 2. Look for simple documentation fixes
 3. Test existing app scripts and report feedback
 4. Share your own setup guides

--- a/docs/features/apps/articles/index.md
+++ b/docs/features/apps/articles/index.md
@@ -17,7 +17,7 @@ For information about creating your own install scripts or contributing to the c
 If you're experiencing issues with a curated app:
 
 1. Check if there's a guide for your app above
-2. Visit the [HexOS Hub](https://hub.hexos.com/) for community discussions
+2. Visit the [HexOS Discord](https://discord.gg/fCW2htvYdz) for community discussions
 3. Review the app's official documentation
 
 For general app installation and management, see the [Apps overview](/features/apps/).

--- a/docs/getting-started/installation/InstallGuide.md
+++ b/docs/getting-started/installation/InstallGuide.md
@@ -1,6 +1,6 @@
 # Illustrated Installation Guide
 
-*by [@Mawson](https://hub.hexos.com/profile/14-mawson/)* with edits by [@gingerling](https://hub.hexos.com/profile/19534-gingerling/) 
+*by @Mawson with edits by @gingerling*
 
 ## Before you Begin
 
@@ -86,14 +86,14 @@ What you see now will depend on how many drives you have in your server. The dri
 ### User Account Setup
 
 -   **Important**: Choose the first option: "Administrative user (truenas_admin)"
--   If you accidentally select the wrong option, [see this solution](https://hub.hexos.com/topic/103-illustrated-installation-guide-start-here/#findComment-1958) or restart the installation
+-   If you accidentally select the wrong option, [see this solution](https://hub.hexos.com/topic/103-illustrated-installation-guide-start-here/#findComment-1958) or restart the installation <!-- TODO: migrate this hub forum link -->
 
 [![User Account Setup](https://hub.hexos.com/uploads/monthly_2024_11/Capture5.PNG.f7af55f85dc45fff3932704006737410.PNG)](https://hub.hexos.com/uploads/monthly_2024_11/Capture5.PNG.f7af55f85dc45fff3932704006737410.PNG "Enlarge image")
 
 ### Set Root Password
 
 -   Set the root password - <span style="color: red;">**Save this password, you'll need it later**</span>
--   **Non-US keyboard users**: Be careful with special characters in the password. The installer uses a [US keyboard layout](https://en.wikipedia.org/wiki/British_and_American_keyboards#/media/File:KB_United_States-NoAltGr.svg). [See details here](https://hub.hexos.com/topic/103-illustrated-installation-guide-start-here/page/2/#findComment-8073) 
+-   **Non-US keyboard users**: Be careful with special characters in the password. The installer uses a [US keyboard layout](https://en.wikipedia.org/wiki/British_and_American_keyboards#/media/File:KB_United_States-NoAltGr.svg). [See details here](https://hub.hexos.com/topic/103-illustrated-installation-guide-start-here/page/2/#findComment-8073) <!-- TODO: migrate this hub forum link -->
 
 [![Root Password Setup](https://hub.hexos.com/uploads/monthly_2024_11/Capture6.PNG.2757a99cb3d6eff2456fae08f5d8af22.PNG)](https://hub.hexos.com/uploads/monthly_2024_11/Capture6.PNG.2757a99cb3d6eff2456fae08f5d8af22.PNG "Enlarge image")
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -31,7 +31,7 @@ Do you have an old PC or gaming rig laying around? Can you get your hands on a d
 
 TrueNAS provides a [comprehensive hardware guide](https://www.truenas.com/docs/scale/gettingstarted/scalehardwareguide/) that covers all aspects of selecting hardware including minimum system requirements, storage devices/controllers, etc.  However, to build an energy efficient server additional research may be required. 
 
-You are welcome to introduce yourself to the HexOS community in [the forum](https://hub.hexos.com/), where you can get further guidance and support on your hardware choices.
+You are welcome to introduce yourself to the HexOS community in [Discord](https://discord.gg/fCW2htvYdz), where you can get further guidance and support on your hardware choices.
 
 ### Buy Pre-Built
 

--- a/docs/getting-started/setup/CompleteSetup.md
+++ b/docs/getting-started/setup/CompleteSetup.md
@@ -99,6 +99,6 @@ This is a good point to check that the install has worked well and that your sys
 
 Whenever you go to [deck.hexos.com](https://deck.hexos.com) you will see your HexOS [dashboard](/features/). This is your control center where you can monitor your server, manage storage, install apps, and configure settings. 
 
-Try clicking on each item on the Dash now and check the details as they pop out from the right hand side of the screen. There should be no warnings or errors and the pool should match what you chose during setup. If you have any problems [try the forums](https://hub.hexos.com/).
+Try clicking on each item on the Dash now and check the details as they pop out from the right hand side of the screen. There should be no warnings or errors and the pool should match what you chose during setup. If you have any problems [try our Discord](https://discord.gg/fCW2htvYdz).
 
 Ready to explore? Check out our [Features Guide](/features/) to learn about everything HexOS can do!

--- a/docs/release-notes/command-deck/2024-11-29.md
+++ b/docs/release-notes/command-deck/2024-11-29.md
@@ -35,7 +35,7 @@ Ready to try HexOS Command Deck? Visit [hexos.com](https://hexos.com) to get sta
 
 ## Feedback Welcome
 
-As a beta release, we're actively seeking feedback from the community. Join the conversation at [HexOS Community](https://hub.hexos.com/) to share your experiences, report issues, and help shape the future of HexOS.
+As a beta release, we're actively seeking feedback from the community. Join the conversation at [HexOS Community](https://discord.gg/fCW2htvYdz) to share your experiences, report issues, and help shape the future of HexOS.
 
 ---
 

--- a/docs/release-notes/command-deck/2025-11-25.md
+++ b/docs/release-notes/command-deck/2025-11-25.md
@@ -4,7 +4,7 @@ We have added 3 highly requested apps to our list of curated apps to enhance you
 
 ## Additional Curations
 
-:::tip These apps are currently in Beta. We welcome your feedback at support@hexos.com or on our [HexOS Hub](https://hub.hexos.com/).
+:::tip These apps are currently in Beta. We welcome your feedback at support@hexos.com or on our [HexOS Discord](https://discord.gg/fCW2htvYdz).
 :::
 
 ### Sonarr

--- a/docs/release-notes/command-deck/2025-12-26.md
+++ b/docs/release-notes/command-deck/2025-12-26.md
@@ -17,7 +17,7 @@ The apps section has been redesigned along with additional curations. New featur
 - **[Draw.io](https://www.drawio.com//)** - A whiteboarding / diagramming software application.
 
 ## Two-Factor Authentication
-You can enable 2FA in your security settings here: [Hub: Security Settings](https://hub.hexos.com/settings/account-security/).
+You can enable 2FA in your security settings here: your HexOS account security settings.
 
 ## Goldeye Support
 TrueNAS 25.10.1 support and upgradability from within Deck. This release uses the NVIDIA open GPU kernel, bringing [wider support](https://forums.truenas.com/t/nvidia-compatible-driver-test-for-truenas-25-10-goldeye/53395) to NVIDIA GPUs. 

--- a/docs/release-notes/command-deck/2026-03-24.md
+++ b/docs/release-notes/command-deck/2026-03-24.md
@@ -38,8 +38,8 @@ As part of a significant infrastructure effort behind the scenes for [HexOS Loca
 
 ### Special Thanks to the the following members of our community
 - [Anna Morris](https://gingerling.co.uk) - For helping with documentation, guides and general feedback.  
-- [AeroXuk](https://hub.hexos.com/profile/494-aeroxuk/) - For reporting and determining the cause of a bug with an install script.
-- [SimJoSt](https://hub.hexos.com/profile/20928-simjost/) - For creating installation scripts for [Gramps](https://www.grampsweb.org/) & [FileBrowser Quantum](https://filebrowserquantum.com) and implementing AeroXuk's bugfix.
+- AeroXuk - For reporting and determining the cause of a bug with an install script.
+- SimJoSt - For creating installation scripts for [Gramps](https://www.grampsweb.org/) & [FileBrowser Quantum](https://filebrowserquantum.com) and implementing AeroXuk's bugfix.
 - [rhjanssen](https://github.com/rhjanssen) - For exploring installation scripts for [OpenCloud](https://opencloud.eu/), [OnlyOffice Document Server](https://www.onlyoffice.com/) & [Collabora Online](https://www.collaboraoffice.com/).
 
 

--- a/docs/release-notes/command-deck/index.md
+++ b/docs/release-notes/command-deck/index.md
@@ -45,4 +45,4 @@ For users who are actively connected during an update, there may be a brief down
 If you encounter any issues after an update:
 - Try [clearing your browser cache](/troubleshooting/common-issues/ClearCache) first
 - Check the [troubleshooting guide](/troubleshooting/) for common solutions
-- Visit the [HexOS Community](https://hub.hexos.com/) for additional support
+- Visit the [HexOS Community](https://discord.gg/fCW2htvYdz) for additional support

--- a/docs/troubleshooting/common-issues/ClearCache.md
+++ b/docs/troubleshooting/common-issues/ClearCache.md
@@ -33,4 +33,4 @@ If you're having trouble logging into the HexOS Deck UI or experiencing session 
 If clearing your cache doesn't resolve the problem:
 - Try using an incognito/private browsing window
 - Restart your browser completely
-- Check the [HexOS Community](https://hub.hexos.com/) for additional support
+- Check the [HexOS Community](https://discord.gg/fCW2htvYdz) for additional support

--- a/docs/troubleshooting/common-issues/index.md
+++ b/docs/troubleshooting/common-issues/index.md
@@ -8,5 +8,5 @@ Having trouble with your HexOS setup? Check out these common issues and solution
 - [**Immich Migration**](./ImmichMigration) - Guide for migrating existing Immich installations to HexOS
 
 :::tip Contribute to Documentation
-Found a solution that worked? [Learn how to contribute](/community/how-to-contribute/) to improve these docs for everyone, submit corrections through the documentation repository, or share your solutions on the [HexOS Community forum](https://hub.hexos.com/).
+Found a solution that worked? [Learn how to contribute](/community/how-to-contribute/) to improve these docs for everyone, submit corrections through the documentation repository, or share your solutions on the [HexOS Community Discord](https://discord.gg/fCW2htvYdz).
 :::

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -9,7 +9,7 @@ Check our [Common Issues](./common-issues/) section for frequently encountered p
 - [Clear Browser Cache](./common-issues/ClearCache) - Fixing login and UI issues
 - [Avoid USB Drives](./common-issues/AvoidUSBDrives) - Why USB drives cause problems
 
-Visit the [HexOS Community](https://hub.hexos.com/) for additional support from other users.
+Visit the [HexOS Community](https://discord.gg/fCW2htvYdz) for additional support from other users.
 :::
 
 ## Installation Issues
@@ -181,7 +181,7 @@ If a task is taking too long or appears stuck in the Activities panel, you can m
 If your issue isn't covered here:
 
 - Check [Common Issues](./common-issues/) for community-reported problems
-- Visit the [HexOS Community](https://hub.hexos.com/) for user support
+- Visit the [HexOS Community](https://discord.gg/fCW2htvYdz) for user support
 - Review the [Getting Started Guide](/getting-started/overview) for setup help
 - Contact HexOS support through the official channels
 

--- a/scripts/generateReleaseNotesIndex.mjs
+++ b/scripts/generateReleaseNotesIndex.mjs
@@ -114,7 +114,7 @@ ${YEAR_SECTIONS_END}
 If you encounter any issues after an update:
 - Try [clearing your browser cache](/troubleshooting/common-issues/ClearCache) first
 - Check the [troubleshooting guide](/troubleshooting/) for common solutions
-- Visit the [HexOS Community](https://hub.hexos.com/) for additional support
+- Visit the [HexOS Community](https://discord.gg/fCW2htvYdz) for additional support
 `
     fs.writeFileSync(INDEX_MD, boilerplate)
   }


### PR DESCRIPTION
Migrates community engagement and support links from the forum (hub.hexos.com) to the official Discord server. This includes updating documentation text, release notes, and script templates, as well as simplifying contributor by-lines by removing forum profile links.
