### PR TITLE
Draft release notes for April 21, 2026 (HexOS 1.0 Local Rollout)

### DIFF
--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -154,6 +154,7 @@ const sidebar: DefaultTheme.SidebarItem[] = [
         collapsed: true,
         items: [
       // auto-generated-release-notes-start
+            { text: '2026-04-21', link: '/release-notes/command-deck/2026-04-21' },
             { text: '2026-03-27', link: '/release-notes/command-deck/2026-03-27' },
             { text: '2026-03-24', link: '/release-notes/command-deck/2026-03-24' },
             { text: '2026-01-21', link: '/release-notes/command-deck/2026-01-21' },

--- a/docs/release-notes/command-deck/2026-04-21.md
+++ b/docs/release-notes/command-deck/2026-04-21.md
@@ -1,0 +1,86 @@
+# April 21, 2026 - HexOS 1.0 w/ Local Rollout Complete
+
+*[@jerodfritz](https://discord.com/users/930585282636558406)*
+
+With the [arrival of HexOS 1.0](/blog/2026-04-02), we shipped the most ambitious milestone in the project's history: a complete migration of every existing customer to [HexOS Local](/blog/2025-11-25), our new locally hosted architecture.  This was one of the most complex operations we've ever tackled.  A staged rollout transitioned thousands of servers incrementally by order of purchase, each requiring automated DNS provisioning, SSL certificate generation, and app installation, all while keeping servers online and data untouched.  Zero planned downtime.  Within two weeks, every active customer was on the new platform.
+
+The result is a fundamentally faster experience.  The majority of your day-to-day interactions with Command Deck now talk directly to your hardware instead of round-tripping through our servers.  Some operations like initial setup, monitoring, and network recovery still rely on our cloud infrastructure to keep things running smoothly behind the scenes.  Pages load faster, app installs respond instantly, and the entire interface feels like the native tool it was always meant to be.  Just as importantly, this new architecture is the foundation for everything ahead: smarter app preconfiguration, buddy backups, and features that simply weren't possible when every action had to pass through the cloud.
+
+This release note covers the stabilization work, bug fixes, and improvements shipped in the wake of that migration.
+
+### Local Migration Complete
+
+All existing HexOS customers have been migrated to the Local architecture.  New customers are now onboarded directly to the Local platform.  The legacy hosted backend has been deprecated.
+
+- Completed incremental migration of all users by order of purchase
+- Resolved an issue where newly claimed servers would connect to the legacy backend if the user's account had already been migrated to Local
+- Fixed edge case where servers rebooted without network connectivity would fail to start the Docker service, causing the setup wizard to re-appear ([EFAULT] Unable to determine default interface)
+- Servers that lose connectivity during boot now recover more gracefully once the network is restored
+- Added recovery retry logic for reinstall steps to handle transient failures during HexOS Local provisioning
+- We've formalized a partnership with Let's Encrypt to issue unique SSL certificates for each server.  This rollout is happening gradually due to rate limits and will replace the shared wildcard certificate that was used during the initial migration.  Revoked certificates are automatically re-provisioned.
+
+### Authentication & Session
+
+- Added a "Remember Me" option on the Local login screen to reduce frequent re-authentication.  We're continuing to tune session duration based on user feedback.
+- Migrated legacy user preferences (Expert Mode, Experimental Features) so they persist after the Local transition
+- Renamed "Username" to "Email" on the authentication screen for clarity
+- Made the "Create Account" link easier to spot during login
+
+### Reliability & Recovery
+
+- Added semaphore-based connection handling to prevent thundering herd issues when many servers reconnect simultaneously after updates
+- Improved handling of TrueNAS disconnections while waiting on Docker status calls
+- Added job tracking IDs to Docker update tasks to prevent stale task states
+- Improved Sentry error fingerprinting for more accurate issue grouping and faster triage
+- Added server lifecycle logging to aid in diagnosing provisioning and recovery issues
+
+### Apps & Catalog
+
+- Fixed app version display mismatch where update prompts showed the install script version instead of the app version (e.g., "upgrade from 2.7.0 to 1.14.0")
+- Prevented multi-step dialogs from closing on outside click during app operations
+- Scheduled catalog sync now includes deprecation metadata and script updates
+- Removed incompatible TrueNAS update messages on startup (specifically the 26.0-BETA.1 notification that was erroneously surfacing)
+- Resolved an issue where curated apps temporarily disappeared from the catalog following a cron task checking for updates
+- Fixed an issue where custom apps installed via TrueNAS were not appearing in the HexOS dashboard after Local migration
+
+### Compatibility
+
+- Changed compile target to support older CPUs that were previously failing to run the Local app
+- Added more diagnostic tools to aid support for fetching app logs from crashed local and possibly incompatible CPU flags
+- Added warnings when a server is running a TrueNAS version that is too old for full HexOS compatibility (Supported TN range: >=24.10.2.2 <26.0.0).  Very early adopters who have not yet upgraded from TrueNAS 24.10.0 or 24.10.2.1 will need to do so manually.  Follow our [upgrade guide](/troubleshooting/common-issues/UpgradingHexOS24) to get to a supported version.
+
+### UI & UX
+
+- Fixed dashboard launch buttons that were greyed out for users on Local when accessed via IP address instead of the local.hexos.com hostname
+- Fixed button styling and state issues across app, server, and pool pages
+- Cleaned up dead links and improved redirect behavior when resetting or unclaiming servers
+- Ensured Samba service is properly enabled and started during provisioning
+- Adjusted compatibility for the new AppUpdate alert class pattern recently introduced that regressed presentation of our app updates available
+
+### New Customer Experience
+
+We've refreshed the first experience for new customers purchasing HexOS post-launch:
+
+- Updated the home page to reflect 1.0 availability and clarified Early Access pricing language
+- Revised the FAQ to confirm that HexOS 1.0 is live and new customers will be updated shortly after install
+- Simplified the cart page with clearer details on what's included with purchase
+- New customers now receive a welcome email with step-by-step getting started links, support contacts, and an invitation to join the community
+
+### What's Next
+
+With the Local rollout behind us, the team is now focused on:
+
+- **Expanding the curated apps catalog** with more one-click installs and deeper preconfiguration
+- **Buddy Backups (1.1)** for peer-to-peer encrypted replication
+- **VM support (1.2)** for creating and managing virtual machines from the HexOS interface
+- **System health improvements** with guided action paths for degraded states and drive failures
+- **New website and ecommerce experience** to support subscription pricing when we sunset lifetime access.  Once the Early Access lifetime price is gone, it's gone forever.
+- **Documentation overhaul** by consolidating community guides from our forums and other sources into [docs.hexos.com](https://docs.hexos.com) as a single, comprehensive knowledge base for all things HexOS.
+
+### Special Thanks
+
+Thank you to everyone in the community who helped us identify and reproduce issues during the Local rollout.  Your willingness to share logs, test edge cases, and provide detailed reports made this a smoother transition for everyone.
+
+We're also bolstering our communication and customer support by rolling out our public [Discord server](https://discord.gg/fCW2htvYdz).  Whether you have a question, want to share feedback, or just want to hang out with the team and other HexOS users, find us there anytime.
+
+**NOTE:** All of these updates are applied automatically to your Command Deck.  You may need to clear your cache.  Help with clearing your cache is available [here](/troubleshooting/common-issues/ClearCache).

--- a/docs/release-notes/command-deck/index.md
+++ b/docs/release-notes/command-deck/index.md
@@ -11,6 +11,7 @@ For users who are actively connected during an update, there may be a brief down
 <!-- auto-generated-year-sections-start -->
 ## 2026 Releases
 
+- [**2026-04-21**](./2026-04-21) - HexOS 1.0 w/ Local Rollout Complete
 - [**2026-03-27**](./2026-03-27) - Hotfix : Apps Newly Curated
 - [**2026-03-24**](./2026-03-24) - Local Foundations & UI Polish
 - [**2026-01-21**](./2026-01-21) - Mobile Dialogs, App Lifecycle, Polish, HexOS Local Prep

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -8,7 +8,7 @@ The Command Deck is the HexOS web interface. Updates are automatically deployed 
 
 **[View Command Deck Release Notes →](/release-notes/command-deck/)**
 
-**Latest:** [2026-03-27 — Hotfix : Apps Newly Curated](/release-notes/command-deck/2026-03-27)
+**Latest:** [2026-04-21 — HexOS 1.0 w/ Local Rollout Complete](/release-notes/command-deck/2026-04-21)
 
 ## TrueNAS
 


### PR DESCRIPTION
Includes documentation for the completion of the HexOS Local architecture migration, along with various improvements to authentication, reliability, and the app catalog.