### PR TITLE
Add Google Tag Manager

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -41,4 +41,12 @@ watch(
 
 <template>
   <DefaultTheme.Layout />
+  <noscript>
+    <iframe
+      src="https://www.googletagmanager.com/ns.html?id=GTM-524ZLZQB"
+      height="0"
+      width="0"
+      style="display: none; visibility: hidden"
+    ></iframe>
+  </noscript>
 </template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,27 @@ import './custom.css'
 import Breadcrumb from './Breadcrumb.vue'
 import Layout from './Layout.vue'
 import { h } from 'vue'
+import type { EnhanceAppContext } from 'vitepress'
+
+declare global {
+  interface Window {
+    dataLayer: Record<string, unknown>[]
+  }
+}
+
+const GTM_ID = 'GTM-524ZLZQB'
+
+function injectGtmScript(): void {
+  if (document.querySelector(`script[src*="googletagmanager.com/gtm.js?id=${GTM_ID}"]`)) return
+
+  window.dataLayer = window.dataLayer || []
+  window.dataLayer.push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtm.js?id=${GTM_ID}`
+  document.head.appendChild(script)
+}
 
 export default {
   extends: DefaultTheme,
@@ -10,5 +31,20 @@ export default {
     return h(Layout, null, {
       'doc-before': () => h(Breadcrumb)
     })
+  },
+  enhanceApp({ router }: EnhanceAppContext) {
+    if (typeof window === 'undefined') return
+
+    injectGtmScript()
+
+    router.onAfterRouteChanged = (to: string) => {
+      window.dataLayer = window.dataLayer || []
+      window.dataLayer.push({
+        event: 'page_view',
+        page_path: to,
+        page_location: window.location.href,
+        page_title: document.title
+      })
+    }
   }
 }


### PR DESCRIPTION
Integrates Google Tag Manager by injecting the GTM script and tracking page views on route changes. Also adds a noscript fallback to the base layout.
