### PR TITLE
Update install script schema to V4 with better permission management and recovery

### DIFF
--- a/docs/features/apps/install-scripts/advanced/debugging.md
+++ b/docs/features/apps/install-scripts/advanced/debugging.md
@@ -27,8 +27,8 @@ If an install scripts fails, this will help:
 
 #### Permission Errors
 - **Symptom**: App fails to start, logs show permission denied errors
-- **Solution**: Add appropriate entries to `ensure_permissions_exists` in your install script
-- **Example**: PostgreSQL requires specific user/group permissions
+- **Solution**: Add the `owner` field to the relevant entry in `ensure_directories_exists` with the correct TrueNAS username (e.g., `"postgres"`, `"apps"`)
+- **Example**: PostgreSQL requires `"owner": "postgres"` on its data directory
 
 #### Missing Directories
 - **Symptom**: App fails during installation, "directory not found" errors

--- a/docs/features/apps/install-scripts/advanced/debugging.md
+++ b/docs/features/apps/install-scripts/advanced/debugging.md
@@ -27,8 +27,8 @@ If an install scripts fails, this will help:
 
 #### Permission Errors
 - **Symptom**: App fails to start, logs show permission denied errors
-- **Solution**: Add the `owner` field to the relevant entry in `ensure_directories_exists` with the correct TrueNAS username (e.g., `"postgres"`, `"apps"`)
-- **Example**: PostgreSQL requires `"owner": "postgres"` on its data directory
+- **Solution**: Add the `owner` field to the relevant entry in `ensure_directories_exists` with the correct TrueNAS user and group (e.g., `{ "user": "netdata", "group": "docker" }`)
+- **Example**: PostgreSQL data directories typically require `"owner": { "user": "netdata", "group": "docker" }`
 
 #### Missing Directories
 - **Symptom**: App fails during installation, "directory not found" errors

--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -3,21 +3,21 @@
 <!-- curated:index:start -->
 | App | Download | Size | Last Modified |
 |---|---|---:|---|
-| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.3 KB | 2026-03-15 |
-| `drawio` | [drawio.json](/install-scripts/drawio.json) | 757 B | 2026-03-15 |
-| `emby` | [emby.json](/install-scripts/emby.json) | 2.2 KB | 2026-03-15 |
-| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.8 KB | 2026-03-15 |
-| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.6 KB | 2026-03-19 |
-| `immich` | [immich.json](/install-scripts/immich.json) | 1.7 KB | 2026-03-15 |
-| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.2 KB | 2026-03-15 |
+| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.4 KB | 2026-03-15 |
+| `drawio` | [drawio.json](/install-scripts/drawio.json) | 634 B | 2026-03-15 |
+| `emby` | [emby.json](/install-scripts/emby.json) | 2.3 KB | 2026-03-15 |
+| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.9 KB | 2026-03-15 |
+| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.4 KB | 2026-03-19 |
+| `immich` | [immich.json](/install-scripts/immich.json) | 1.5 KB | 2026-03-15 |
+| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.3 KB | 2026-03-15 |
 | `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.4 KB | 2026-03-15 |
-| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.5 KB | 2026-03-15 |
-| `peanut` | [peanut.json](/install-scripts/peanut.json) | 834 B | 2026-03-15 |
+| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.4 KB | 2026-03-15 |
+| `peanut` | [peanut.json](/install-scripts/peanut.json) | 911 B | 2026-03-15 |
 | `plex` | [plex.json](/install-scripts/plex.json) | 3.4 KB | 2025-12-12 |
-| `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 766 B | 2025-12-04 |
+| `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 781 B | 2025-12-04 |
 | `qbittorrent` | [qbittorrent.json](/install-scripts/qbittorrent.json) | 1.0 KB | 2025-12-04 |
-| `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.2 KB | 2025-12-04 |
-| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.3 KB | 2026-03-15 |
-| `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.2 KB | 2025-12-04 |
-| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.5 KB | 2026-05-05 |
+| `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.3 KB | 2025-12-04 |
+| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.4 KB | 2026-03-15 |
+| `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.3 KB | 2025-12-04 |
+| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.6 KB | 2026-05-05 |
 <!-- curated:index:end -->

--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -3,21 +3,21 @@
 <!-- curated:index:start -->
 | App | Download | Size | Last Modified |
 |---|---|---:|---|
-| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.4 KB | 2026-03-15 |
-| `drawio` | [drawio.json](/install-scripts/drawio.json) | 634 B | 2026-03-15 |
-| `emby` | [emby.json](/install-scripts/emby.json) | 2.3 KB | 2026-03-15 |
-| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.9 KB | 2026-03-15 |
-| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.4 KB | 2026-03-19 |
-| `immich` | [immich.json](/install-scripts/immich.json) | 1.5 KB | 2026-03-15 |
-| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.3 KB | 2026-03-15 |
-| `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.4 KB | 2026-03-15 |
-| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.4 KB | 2026-03-15 |
-| `peanut` | [peanut.json](/install-scripts/peanut.json) | 911 B | 2026-03-15 |
-| `plex` | [plex.json](/install-scripts/plex.json) | 3.4 KB | 2025-12-12 |
-| `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 781 B | 2025-12-04 |
-| `qbittorrent` | [qbittorrent.json](/install-scripts/qbittorrent.json) | 1.0 KB | 2025-12-04 |
-| `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.3 KB | 2025-12-04 |
-| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.4 KB | 2026-03-15 |
-| `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.3 KB | 2025-12-04 |
-| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.6 KB | 2026-05-05 |
+| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.4 KB | 2026-05-15 |
+| `drawio` | [drawio.json](/install-scripts/drawio.json) | 634 B | 2026-05-15 |
+| `emby` | [emby.json](/install-scripts/emby.json) | 2.3 KB | 2026-05-15 |
+| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.9 KB | 2026-05-15 |
+| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.4 KB | 2026-05-15 |
+| `immich` | [immich.json](/install-scripts/immich.json) | 1.6 KB | 2026-05-15 |
+| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.3 KB | 2026-05-15 |
+| `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.4 KB | 2026-05-15 |
+| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.4 KB | 2026-05-15 |
+| `peanut` | [peanut.json](/install-scripts/peanut.json) | 911 B | 2026-05-15 |
+| `plex` | [plex.json](/install-scripts/plex.json) | 3.4 KB | 2026-05-15 |
+| `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 781 B | 2026-05-15 |
+| `qbittorrent` | [qbittorrent.json](/install-scripts/qbittorrent.json) | 1.0 KB | 2026-05-15 |
+| `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.3 KB | 2026-05-15 |
+| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.4 KB | 2026-05-15 |
+| `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.3 KB | 2026-05-15 |
+| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.6 KB | 2026-05-15 |
 <!-- curated:index:end -->

--- a/docs/features/apps/install-scripts/overview.md
+++ b/docs/features/apps/install-scripts/overview.md
@@ -49,10 +49,12 @@ For apps not yet curated or when you need to customize the configuration:
 ### Best Practices and Common Pitfalls
 
 #### Best Practices
+- **Use V4 format** — all new install scripts must use `"version": 4`
 - **Always use `$LOCATION()` macros** for paths instead of hardcoded paths
 - **Use `$HOST_PATH()` and `$MOUNTED_HOST_PATH()`** for storage configuration instead of manual object creation
-- **Include necessary directories** in `ensure_directories_exists` - assume no directories exist
-- **Set proper permissions** with `ensure_permissions_exists` for apps that require specific user/group access
+- **All directory entries must be objects** — bare strings in `ensure_directories_exists` are no longer supported in V4
+- **Declare ownership** with the `owner` field for apps that require specific user/group ownership (e.g., `"postgres"`, `"apps"`)
+- **Add `snapshot` config** on data and config directories to enable automatic pre-update ZFS snapshots
 - **Use `$MEMORY()` for dynamic memory allocation** to ensure apps work across different system configurations
 - **Reference TrueNAS app schemas** from the [official apps repository](https://github.com/truenas/apps) for `app_values` structure
 

--- a/docs/features/apps/install-scripts/reference/schema.md
+++ b/docs/features/apps/install-scripts/reference/schema.md
@@ -82,8 +82,8 @@ Locations are folder paths configured in HexOS Settings → Locations. Each loca
     "locations": ["ApplicationsPerformance", "Photos", "Media"]
   },
   "ensure_directories_exists": [
-    { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": "apps" },
-    { "path": "$LOCATION(Photos)/immich", "owner": "apps" }
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": { "user": "apps" } },
+    { "path": "$LOCATION(Photos)/immich", "owner": { "user": "apps" } }
   ],
   "app_values": {
     "storage": {
@@ -239,7 +239,9 @@ Each entry in `ensure_directories_exists` is an object with the following proper
 
 - `path` (required): Directory path, typically using `$LOCATION()` macros
 - `network_share` (optional): Boolean, whether to expose as a network share
-- `owner` (optional): TrueNAS username that should own this directory (e.g., `"apps"`, `"postgres"`). When specified, HexOS resolves the username to its uid/gid at runtime and ensures correct ownership on install and after updates
+- `owner` (optional): Object specifying the TrueNAS user and group that should own this directory
+  - `user` (required): TrueNAS username (e.g., `"apps"`, `"netdata"`)
+  - `group` (optional): TrueNAS group name (e.g., `"docker"`). If omitted, uses the user's default group
 - `snapshot` (optional): Object with an `id` field. When present, HexOS snapshots this dataset before app updates so support can assist with restoring your application and data if something goes wrong
   - `id` (required): Identifier included in the snapshot name and metadata (e.g., `"pgdata"`, `"config"`)
 
@@ -249,15 +251,15 @@ Each entry in `ensure_directories_exists` is an object with the following proper
   "ensure_directories_exists": [
     { "path": "$LOCATION(Photos)", "network_share": true },
     { "path": "$LOCATION(ApplicationsPerformance)", "network_share": true },
-    { "path": "$LOCATION(Photos)/immich", "owner": "apps", "snapshot": { "id": "data" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": "apps", "snapshot": { "id": "config" } }
+    { "path": "$LOCATION(Photos)/immich", "owner": { "user": "apps" }, "snapshot": { "id": "data" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": { "user": "apps" }, "snapshot": { "id": "config" } }
   ]
 }
 ```
 
 **How `owner` works:**
-- HexOS calls `user.get_user_obj` on the TrueNAS system to resolve the username to a numeric uid/gid
+- HexOS calls `user.get_user_obj` and optionally `group.get_group_obj` on the TrueNAS system to resolve usernames and group names to numeric uid/gid
 - After `app.update` completes, HexOS verifies and repairs ownership on declared paths if TrueNAS changed it
 - If a path has a POSIX1E ACL (legacy), HexOS automatically migrates it to NFS4 with `aclmode: PASSTHROUGH`, snapshots the dataset first as a rollback point, then applies the canonical ACL with the declared uid/gid
 - Only applies to app-specific paths (4+ path segments, e.g., `/mnt/pool/location/app/data`) — location roots are never modified

--- a/docs/features/apps/install-scripts/reference/schema.md
+++ b/docs/features/apps/install-scripts/reference/schema.md
@@ -4,15 +4,14 @@ Install scripts are JSON objects with the following structure. Scripts can use v
 
 ## Root Properties
 
-- **`version`** (required): Schema version. Must be `3` or higher (currently latest supported version).
+- **`version`** (required): Schema version. Must be `4` (current required version). Versions 1-3 are deprecated.
 - **`script`** (required): Metadata about the install script itself
   - **`version`** (required): Semantic version of this install script (e.g., "1.0.0", "2.1.3")
   - **`updateCompatibility`** (optional): Semver range expression defining which script versions can update to this version (e.g., ">=1.0.0" allows updates from any version 1.0.0 or higher, "^2.0.0" allows updates from 2.x.x versions). Supports all [semver range syntax](https://www.npmjs.com/package/semver#ranges) including `>=`, `>`, `<`, `<=`, `^`, `~`, and complex ranges like `">=1.0.0 <3.0.0"`
   - **`changeLog`** (optional): Description of changes in this version of the script
 - **`requirements`** (required): System requirements that are validated before installation
 - **`installation_questions`** (optional): Array of questions to ask the user during installation
-- **`ensure_directories_exists`** (optional): Array of directories to create before installation
-- **`ensure_permissions_exists`** (optional): Array of permission modifications for specific paths
+- **`ensure_directories_exists`** (optional): Array of directory entry objects to create before installation, with optional ownership and snapshot declarations
 - **`app_values`** (required): Configuration object passed directly to TrueNAS API
 
 ## Available Macros
@@ -83,8 +82,8 @@ Locations are folder paths configured in HexOS Settings → Locations. Each loca
     "locations": ["ApplicationsPerformance", "Photos", "Media"]
   },
   "ensure_directories_exists": [
-    "$LOCATION(ApplicationsPerformance)/immich/config",
-    "$LOCATION(Photos)/immich"
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": "apps" },
+    { "path": "$LOCATION(Photos)/immich", "owner": "apps" }
   ],
   "app_values": {
     "storage": {
@@ -149,7 +148,7 @@ Network ports that the application will use. HexOS can validate port availabilit
 
 ```json
 {
-  "version": 2,
+  "version": 4,
   "requirements": {
     "locations": [
       "ApplicationsPerformance",
@@ -234,19 +233,41 @@ Reference question responses in your `app_values` using the `$QUESTION(key)` syn
 
 Question responses can be used in conditional logic with the `$IF` macro. See the [$IF macro documentation](/features/apps/install-scripts/reference/macros#if-condition-truevalue-falsevalue) for examples of using questions in conditional expressions.
 
-## Directory Creation
-- **String format**: Simple path string
-- **Object format**: 
-  - `path`: Directory path (required)
-  - `network_share`: Boolean, whether to expose as network share
-  - `posix`: Boolean, whether to use POSIX permissions
+## Directory Creation, Ownership, and Snapshots
 
-## Permission Management
-Required for apps that need specific user/group permissions (like PostgreSQL).
-- `path`: Directory path to modify
-- `username`: User to grant access to
-- `access`: Access level ("read", "write", etc.)
-- `posix`: Object with additional POSIX settings (e.g., `groupname`)
+Each entry in `ensure_directories_exists` is an object with the following properties:
+
+- `path` (required): Directory path, typically using `$LOCATION()` macros
+- `network_share` (optional): Boolean, whether to expose as a network share
+- `owner` (optional): TrueNAS username that should own this directory (e.g., `"apps"`, `"postgres"`). When specified, HexOS resolves the username to its uid/gid at runtime and ensures correct ownership on install and after updates
+- `snapshot` (optional): Object with an `id` field. When present, HexOS snapshots this dataset before app updates so support can assist with restoring your application and data if something goes wrong
+  - `id` (required): Identifier included in the snapshot name and metadata (e.g., `"pgdata"`, `"config"`)
+
+**Example:**
+```json
+{
+  "ensure_directories_exists": [
+    { "path": "$LOCATION(Photos)", "network_share": true },
+    { "path": "$LOCATION(ApplicationsPerformance)", "network_share": true },
+    { "path": "$LOCATION(Photos)/immich", "owner": "apps", "snapshot": { "id": "data" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": "apps", "snapshot": { "id": "config" } }
+  ]
+}
+```
+
+**How `owner` works:**
+- HexOS calls `user.get_user_obj` on the TrueNAS system to resolve the username to a numeric uid/gid
+- After `app.update` completes, HexOS verifies and repairs ownership on declared paths if TrueNAS changed it
+- If a path has a POSIX1E ACL (legacy), HexOS automatically migrates it to NFS4 with `aclmode: PASSTHROUGH`, snapshots the dataset first as a rollback point, then applies the canonical ACL with the declared uid/gid
+- Only applies to app-specific paths (4+ path segments, e.g., `/mnt/pool/location/app/data`) — location roots are never modified
+- Paths without `owner` are created with default permissions and not tracked for repair
+
+**How `snapshot` works:**
+- Before any app update, HexOS snapshots each dataset with a `snapshot` config so support can assist with restoring your application and data if something goes wrong
+- Snapshots are named `hexos-app-{appId}-{id}-{timestamp}` and stamped with metadata: `hexos:purpose`, `hexos:app`, `hexos:snapshot_id`, `hexos:path`
+- Only the latest 3 snapshots per app per dataset are kept — older snapshots are automatically pruned after each new snapshot
+- Only applies to app-specific paths (4+ path segments) — location roots are never snapshotted
 
 ## App Values
 This object is passed directly to TrueNAS's app installation API. The structure varies by application and corresponds to the app's configuration schema in the [TrueNAS apps repository](https://github.com/truenas/apps). For example, you can see Plex's schema for the `storage` property [here](https://github.com/truenas/apps/blob/1d2a6e9811f9af2ceae6529cc094a432a7da4e96/trains/stable/plex/app_versions.json#L422).

--- a/docs/features/apps/install-scripts/reference/schema.md
+++ b/docs/features/apps/install-scripts/reference/schema.md
@@ -243,7 +243,7 @@ Each entry in `ensure_directories_exists` is an object with the following proper
   - `user` (required): TrueNAS username (e.g., `"apps"`, `"netdata"`)
   - `group` (optional): TrueNAS group name (e.g., `"docker"`). If omitted, uses the user's default group
 - `snapshot` (optional): Object with an `id` field. When present, HexOS snapshots this dataset before app updates so support can assist with restoring your application and data if something goes wrong
-  - `id` (required): Identifier included in the snapshot name and metadata (e.g., `"pgdata"`, `"config"`)
+  - `id` (required): Identifier included in the snapshot name and metadata (e.g., `"db"`, `"config"`)
 
 **Example:**
 ```json
@@ -252,7 +252,7 @@ Each entry in `ensure_directories_exists` is an object with the following proper
     { "path": "$LOCATION(Photos)", "network_share": true },
     { "path": "$LOCATION(ApplicationsPerformance)", "network_share": true },
     { "path": "$LOCATION(Photos)/immich", "owner": { "user": "apps" }, "snapshot": { "id": "data" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "db" } },
     { "path": "$LOCATION(ApplicationsPerformance)/immich/config", "owner": { "user": "apps" }, "snapshot": { "id": "config" } }
   ]
 }

--- a/docs/public/install-scripts/bazarr.json
+++ b/docs/public/install-scripts/bazarr.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -37,7 +37,10 @@
       "path": "$LOCATION(Shows)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/bazarr/config"
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/bazarr/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/drawio.json
+++ b/docs/public/install-scripts/drawio.json
@@ -1,32 +1,32 @@
 {
-    "version": 3,
-    "script": {
-        "version": "1.0.1",
-        "changeLog": "Updated requirements"
+  "version": 4,
+  "script": {
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
+  },
+  "requirements": {
+    "locations": [],
+    "specifications": ["2CORE", "1024MB"],
+    "permissions": [],
+    "ports": [30090, 30091]
+  },
+  "ensure_directories_exists": [],
+  "app_values": {
+    "network": {
+      "http_port": {
+        "bind_mode": "published",
+        "port_number": 30090
+      },
+      "https_port": {
+        "bind_mode": "published",
+        "port_number": 30091
+      }
     },
-    "requirements": {
-        "locations": [],
-        "specifications": ["2CORE", "1024MB"],
-        "permissions": [],
-        "ports": [30090, 30091]
-    },
-    "ensure_directories_exists": [],
-    "app_values": {
-        "network": {
-            "http_port": {
-                "bind_mode": "published",
-                "port_number": 30090
-            },
-            "https_port": {
-                "bind_mode": "published",
-                "port_number": 30091
-            }
-        },
-        "resources": {
-            "limits": {
-                "cpus": 2,
-                "memory": "$MEMORY(5%, 1024)"
-            }
-        }
+    "resources": {
+      "limits": {
+        "cpus": 2,
+        "memory": "$MEMORY(5%, 1024)"
+      }
     }
+  }
 }

--- a/docs/public/install-scripts/emby.json
+++ b/docs/public/install-scripts/emby.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.2",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "ApplicationsCapacity", "Media", "Photos", "Music", "Movies", "Shows", "Videos"],
@@ -43,9 +43,9 @@
       "path": "$LOCATION(Videos)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/emby/config",
-    "$LOCATION(ApplicationsPerformance)/emby/cache",
-    "$LOCATION(ApplicationsPerformance)/emby/transcode"
+    { "path": "$LOCATION(ApplicationsPerformance)/emby/config", "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/emby/cache" },
+    { "path": "$LOCATION(ApplicationsPerformance)/emby/transcode" }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/handbrake.json
+++ b/docs/public/install-scripts/handbrake.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -44,8 +44,13 @@
       "path": "$LOCATION(Videos)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/handbrake/config",
-    "$LOCATION(Media)/HandBrake/Output"
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/handbrake/config",
+      "snapshot": { "id": "config" }
+    },
+    {
+      "path": "$LOCATION(Media)/HandBrake/Output"
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/home-assistant.json
+++ b/docs/public/install-scripts/home-assistant.json
@@ -20,7 +20,7 @@
       "network_share": true
     },
     { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/config", "owner": { "user": "apps" }, "snapshot": { "id": "config" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "db" } },
     { "path": "$LOCATION(Media)/home-assistant" }
   ],
   "app_values": {

--- a/docs/public/install-scripts/home-assistant.json
+++ b/docs/public/install-scripts/home-assistant.json
@@ -19,8 +19,8 @@
       "path": "$LOCATION(Media)",
       "network_share": true
     },
-    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/config", "owner": "apps", "snapshot": { "id": "config" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/config", "owner": { "user": "apps" }, "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } },
     { "path": "$LOCATION(Media)/home-assistant" }
   ],
   "app_values": {

--- a/docs/public/install-scripts/home-assistant.json
+++ b/docs/public/install-scripts/home-assistant.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated dataset locations and set config to posix"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "Media"],
@@ -19,25 +19,9 @@
       "path": "$LOCATION(Media)",
       "network_share": true
     },
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/home-assistant/config",
-      "posix": true
-    },
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data",
-      "posix": true
-    },
-    "$LOCATION(Media)/home-assistant"
-  ],
-  "ensure_permissions_exists": [
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data",
-      "username": "netdata",
-      "access": "read",
-      "posix": {
-        "groupname": "docker"
-      }
-    }
+    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/config", "owner": "apps", "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/home-assistant/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(Media)/home-assistant" }
   ],
   "app_values": {
     "home_assistant": {

--- a/docs/public/install-scripts/immich.json
+++ b/docs/public/install-scripts/immich.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "Photos"],
@@ -19,21 +19,8 @@
       "path": "$LOCATION(Photos)",
       "network_share": true
     },
-    "$LOCATION(Photos)/immich",
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data",
-      "posix": true
-    }
-  ],
-  "ensure_permissions_exists": [
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data",
-      "username": "netdata",
-      "access": "read",
-      "posix": {
-        "groupname": "docker"
-      }
-    }
+    { "path": "$LOCATION(Photos)/immich", "owner": "apps", "snapshot": { "id": "data" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } }
   ],
   "app_values": {
     "release_name": "immich",

--- a/docs/public/install-scripts/immich.json
+++ b/docs/public/install-scripts/immich.json
@@ -20,7 +20,7 @@
       "network_share": true
     },
     { "path": "$LOCATION(Photos)/immich", "owner": { "user": "apps" }, "snapshot": { "id": "data" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } }
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "db" } }
   ],
   "app_values": {
     "release_name": "immich",

--- a/docs/public/install-scripts/immich.json
+++ b/docs/public/install-scripts/immich.json
@@ -19,8 +19,8 @@
       "path": "$LOCATION(Photos)",
       "network_share": true
     },
-    { "path": "$LOCATION(Photos)/immich", "owner": "apps", "snapshot": { "id": "data" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } }
+    { "path": "$LOCATION(Photos)/immich", "owner": { "user": "apps" }, "snapshot": { "id": "data" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/immich/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } }
   ],
   "app_values": {
     "release_name": "immich",

--- a/docs/public/install-scripts/jellyfin.json
+++ b/docs/public/install-scripts/jellyfin.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "ApplicationsCapacity", "Media", "Photos", "Music", "Movies", "Shows", "Videos"],
@@ -43,9 +43,9 @@
       "path": "$LOCATION(Videos)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/jellyfin/config",
-    "$LOCATION(ApplicationsCapacity)/jellyfin/cache",
-    "$LOCATION(ApplicationsPerformance)/jellyfin/transcodes"
+    { "path": "$LOCATION(ApplicationsPerformance)/jellyfin/config", "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsCapacity)/jellyfin/cache" },
+    { "path": "$LOCATION(ApplicationsPerformance)/jellyfin/transcodes" }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/lidarr.json
+++ b/docs/public/install-scripts/lidarr.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -37,8 +37,13 @@
       "path": "$LOCATION(Music)",
       "network_share": true
     },
-    "$LOCATION(Downloads)/qbittorrent",
-    "$LOCATION(ApplicationsPerformance)/lidarr/config"
+    {
+      "path": "$LOCATION(Downloads)/qbittorrent"
+    },
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/lidarr/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/nextcloud.json
+++ b/docs/public/install-scripts/nextcloud.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -47,26 +47,13 @@
       "path": "$LOCATION(ApplicationsPerformance)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/nextcloud/html",
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data",
-      "posix": true
-    },
+    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/html", "owner": "apps", "snapshot": { "id": "html" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } },
     {
       "path": "$LOCATION(ApplicationsCapacity)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsCapacity)/nextcloud/data"
-  ],
-  "ensure_permissions_exists": [
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data",
-      "username": "netdata",
-      "access": "read",
-      "posix": {
-        "groupname": "docker"
-      }
-    }
+    { "path": "$LOCATION(ApplicationsCapacity)/nextcloud/data", "snapshot": { "id": "data" } }
   ],
   "app_values": {
     "nextcloud": {

--- a/docs/public/install-scripts/nextcloud.json
+++ b/docs/public/install-scripts/nextcloud.json
@@ -48,7 +48,7 @@
       "network_share": true
     },
     { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/html", "owner": { "user": "apps" }, "snapshot": { "id": "html" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "db" } },
     {
       "path": "$LOCATION(ApplicationsCapacity)",
       "network_share": true

--- a/docs/public/install-scripts/nextcloud.json
+++ b/docs/public/install-scripts/nextcloud.json
@@ -47,8 +47,8 @@
       "path": "$LOCATION(ApplicationsPerformance)",
       "network_share": true
     },
-    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/html", "owner": "apps", "snapshot": { "id": "html" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data", "owner": "postgres", "snapshot": { "id": "pgdata" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/html", "owner": { "user": "apps" }, "snapshot": { "id": "html" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/nextcloud/postgres_data", "owner": { "user": "netdata", "group": "docker" }, "snapshot": { "id": "pgdata" } },
     {
       "path": "$LOCATION(ApplicationsCapacity)",
       "network_share": true

--- a/docs/public/install-scripts/peanut.json
+++ b/docs/public/install-scripts/peanut.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -22,7 +22,10 @@
       "path": "$LOCATION(ApplicationsPerformance)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/peanut/config"
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/peanut/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/plex.json
+++ b/docs/public/install-scripts/plex.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.0",
-    "changeLog": "Upgraded Plex install script to be compatible with latest HexOS script changes"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "installation_questions": [
     {
@@ -72,13 +72,10 @@
       "path": "$LOCATION(Videos)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/plex/data",
-    {
-      "path": "$LOCATION(ApplicationsPerformance)/plex/config",
-      "posix": true
-    },
-    "$LOCATION(ApplicationsCapacity)/plex/logs",
-    "$LOCATION(ApplicationsPerformance)/plex/transcode"
+    { "path": "$LOCATION(ApplicationsPerformance)/plex/data", "owner": "apps", "snapshot": { "id": "data" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/plex/config", "owner": "apps", "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsCapacity)/plex/logs" },
+    { "path": "$LOCATION(ApplicationsPerformance)/plex/transcode" }
   ],
   "app_values": {
     "plex": {

--- a/docs/public/install-scripts/plex.json
+++ b/docs/public/install-scripts/plex.json
@@ -72,8 +72,8 @@
       "path": "$LOCATION(Videos)",
       "network_share": true
     },
-    { "path": "$LOCATION(ApplicationsPerformance)/plex/data", "owner": "apps", "snapshot": { "id": "data" } },
-    { "path": "$LOCATION(ApplicationsPerformance)/plex/config", "owner": "apps", "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/plex/data", "owner": { "user": "apps" }, "snapshot": { "id": "data" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/plex/config", "owner": { "user": "apps" }, "snapshot": { "id": "config" } },
     { "path": "$LOCATION(ApplicationsCapacity)/plex/logs" },
     { "path": "$LOCATION(ApplicationsPerformance)/plex/transcode" }
   ],

--- a/docs/public/install-scripts/prowlarr.json
+++ b/docs/public/install-scripts/prowlarr.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.0",
-    "changeLog": "Upgraded Prowlarr install script to be compatible with latest HexOS script changes"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance"],
@@ -15,7 +15,10 @@
       "path": "$LOCATION(ApplicationsPerformance)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/prowlarr/config"
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/prowlarr/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/qbittorrent.json
+++ b/docs/public/install-scripts/qbittorrent.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.0",
-    "changeLog": "Upgraded qBittorrent install script to be compatible with latest HexOS script changes"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "ApplicationsCapacity", "Downloads"],
@@ -23,8 +23,13 @@
       "path": "$LOCATION(Downloads)",
       "network_share": true
     },
-    "$LOCATION(Downloads)/qbittorrent",
-    "$LOCATION(ApplicationsPerformance)/qbittorrent/config"
+    {
+      "path": "$LOCATION(Downloads)/qbittorrent"
+    },
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/qbittorrent/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/radarr.json
+++ b/docs/public/install-scripts/radarr.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.0",
-    "changeLog": "Upgraded Radarr install script to be compatible with latest HexOS script changes"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "ApplicationsCapacity", "Downloads", "Movies"],
@@ -27,8 +27,13 @@
       "path": "$LOCATION(Movies)",
       "network_share": true
     },
-    "$LOCATION(Downloads)/qbittorrent",
-    "$LOCATION(ApplicationsPerformance)/radarr/config"
+    {
+      "path": "$LOCATION(Downloads)/qbittorrent"
+    },
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/radarr/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/scrutiny.json
+++ b/docs/public/install-scripts/scrutiny.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.1",
-    "changeLog": "Updated requirements"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -22,8 +22,8 @@
       "path": "$LOCATION(ApplicationsPerformance)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/scrutiny/config",
-    "$LOCATION(ApplicationsPerformance)/scrutiny/influxdb"
+    { "path": "$LOCATION(ApplicationsPerformance)/scrutiny/config", "snapshot": { "id": "config" } },
+    { "path": "$LOCATION(ApplicationsPerformance)/scrutiny/influxdb", "snapshot": { "id": "influxdb" } }
   ],
   "app_values": {
     "network": {

--- a/docs/public/install-scripts/sonarr.json
+++ b/docs/public/install-scripts/sonarr.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.0",
-    "changeLog": "Upgraded Sonarr install script to be compatible with latest HexOS script changes"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": ["ApplicationsPerformance", "ApplicationsCapacity", "Downloads", "Shows"],
@@ -27,8 +27,13 @@
       "path": "$LOCATION(Shows)",
       "network_share": true
     },
-    "$LOCATION(Downloads)/qbittorrent",
-    "$LOCATION(ApplicationsPerformance)/sonarr/config"
+    {
+      "path": "$LOCATION(Downloads)/qbittorrent"
+    },
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/sonarr/config",
+      "snapshot": { "id": "config" }
+    }
   ],
   "app_values": {
     "storage": {

--- a/docs/public/install-scripts/syncthing.json
+++ b/docs/public/install-scripts/syncthing.json
@@ -1,8 +1,8 @@
 {
-  "version": 3,
+  "version": 4,
   "script": {
-    "version": "1.0.2",
-    "changeLog": "add access to media, movies, shows"
+    "version": "1.1.0",
+    "changeLog": "Upgraded to V4 install script format"
   },
   "requirements": {
     "locations": [
@@ -67,7 +67,7 @@
       "path": "$LOCATION(Shows)",
       "network_share": true
     },
-    "$LOCATION(ApplicationsPerformance)/syncthing/config"
+    { "path": "$LOCATION(ApplicationsPerformance)/syncthing/config", "snapshot": { "id": "config" } }
   ],
   "app_values": {
     "run_as": {


### PR DESCRIPTION
This release introduces the V4 install script schema, centralizing directory creation, ownership, and ZFS snapshot declarations under `ensure_directories_exists` in preparation for buddy backups.

Key changes include:
- `ensure_directories_exists` entries must now be objects and can specify `owner` and `snapshot` fields.
- The separate `ensure_permissions_exists` section is deprecated and removed.
- V4 is now the required schema version for all new install scripts.

This simplifies script development by unifying directory configuration and improves data safety with automatic pre-update snapshots. All example install scripts have been migrated to the new V4 format.
