### PR TITLE
feat: Introduce V5 install scripts with lifecycle hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,0 @@
-npm run gen:all
-git add .

--- a/docs/.vitepress/sidebar.ts
+++ b/docs/.vitepress/sidebar.ts
@@ -43,6 +43,7 @@ const sidebar: DefaultTheme.SidebarItem[] = [
               { text: 'Curated Scripts', link: '/features/apps/install-scripts/curated/' },
               { text: 'Contributing', link: '/features/apps/install-scripts/contributing' },
               { text: 'Schema Reference', link: '/features/apps/install-scripts/reference/schema' },
+              { text: 'Hooks Reference', link: '/features/apps/install-scripts/reference/hooks' },
               { text: 'Macros Reference', link: '/features/apps/install-scripts/reference/macros' },
               { text: 'Debugging', link: '/features/apps/install-scripts/advanced/debugging' },
             ]

--- a/docs/features/apps/install-scripts/advanced/debugging.md
+++ b/docs/features/apps/install-scripts/advanced/debugging.md
@@ -1,17 +1,35 @@
 ## Debugging Workflow : Troubleshooting Failed Installations
 
-If an install scripts fails, this will help:
+If an install script fails, this will help:
 
 ### 1. Check HexOS Task Failure
 1. In the HexOS UI, check your notifications for an app install failure
 2. Click the notification to view the error message
 
-### 2. Check TrueNAS Job Failure
+### 2. Check Hook Failures (V5 Scripts)
+
+If your install script uses lifecycle hooks, hook tasks appear as children of the main install task in the HexOS activity center:
+
+1. Open the **Activity Center** (bell icon) in the HexOS UI
+2. Expand the install task to see individual hook steps
+3. Each hook shows its checkpoints and current status
+4. If a hook failed:
+   - Click **View Details** to see structured error context (endpoint, status code, etc.)
+   - Click **Retry** to re-run the hook from the failed checkpoint
+   - Click **Skip** to skip the hook and continue (if allowed)
+
+**Common hook failure causes:**
+- **App not ready** — the container hasn't finished starting. Increase the hook's `timeout` or add a longer delay in `waitForApp()`
+- **Network unreachable** — the hook can't reach the app's HTTP endpoint. Check that the port is correct and the app binds to `0.0.0.0`
+- **OAuth timeout** — the user didn't complete the OAuth flow within the time limit. Retry the hook to get a fresh OAuth prompt
+- **Missing input** — a required hook input wasn't provided. Check your `inputs` declarations
+
+### 3. Check TrueNAS Job Failure
 1. Navigate to the TrueNAS web interface (e.g., `https://10.0.1.13`)
 2. Go to **Jobs** section to view the installation job details
 3. Look for error messages in the detailed job output
 
-### 3. Check Application Logs (if app installed but won't start)
+### 4. Check Application Logs (if app installed but won't start)
 **Option A: TrueNAS Apps UI (if container is running)**
 1. Navigate to `https://10.0.1.13/ui/apps/installed`
 2. Click on the app, under `Workloads > Containers`, click the "View Logs" button
@@ -23,7 +41,7 @@ If an install scripts fails, this will help:
 3. Copy the container ID
 4. Run `sudo docker logs <container_id>` to view detailed logs
 
-### 3. Common Issues and Solutions
+### 5. Common Issues and Solutions
 
 #### Permission Errors
 - **Symptom**: App fails to start, logs show permission denied errors
@@ -37,6 +55,13 @@ If an install scripts fails, this will help:
 #### Invalid App Configuration
 - **Symptom**: TrueNAS job fails with validation errors
 - **Solution**: Compare your `app_values` structure with the official TrueNAS app schema
+
+#### Hook Script Errors
+- **Symptom**: Hook task shows `AWAITING_RETRY` with an error message
+- **Solution**: Check the error context details for the specific failure. Common fixes:
+  - Ensure the `entrypoint` function name matches what's exported in your script
+  - Verify the app's API endpoint path is correct
+  - Confirm all `await` keywords are present on async calls
 
 ### Future Improvements
 The current debugging workflow requires accessing the TrueNAS interface directly, in the future we plan to expose more of this debugging workflow within HexOS's UI.

--- a/docs/features/apps/install-scripts/contributing.md
+++ b/docs/features/apps/install-scripts/contributing.md
@@ -1,10 +1,77 @@
-# Contributing a new app
+# Contributing a New App
 
-Want to add your app curation to the official HexOS catalog? Follow these steps to contribute your install script, or share it in our forums first to get community feedback:
+Want to add your app curation to the official HexOS catalog? Install scripts now live in the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository — this is the single source of truth for all curated and community install scripts.
 
-1. Test your custom curation in HexOS and verify it works reliably
-2. Click [Here](https://github.com/eshtek/hexos-docs/new/main/docs/public/install-scripts) to start the contribution process
-3. Click the green "Fork this repository" button
-4. Paste the contents of your install script into the editor and press the green "Commit Changes"
-5. Click the green "Create pull request" on the following page
-6. In your PR description, include any special requirements (unique mounts, GPU usage, special environment variables, etc.)
+## Contribution Steps
+
+1. **Test your install script** in HexOS using Custom Install (Expert Mode) and verify it works reliably
+2. **Fork** the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository
+3. **Add your install script** as a JSON file named after the TrueNAS app (e.g., `myapp.json`)
+4. **If your script includes hooks** (V5), add the hook `.ts` files in a subdirectory (e.g., `myapp/myapp_hook.ts`) — or use inline `scriptContent` for simpler hooks
+5. **Submit a Pull Request** with a description of:
+   - What the app does
+   - Any special requirements (unique mounts, GPU usage, special environment variables)
+   - What the hooks do (if V5)
+
+## Repository Structure
+
+```
+hexos-app-catalog/
+├── _lib/
+│   └── hook_context.ts        # HookContext type stubs (import for autocompletion)
+├── myapp.json                 # Your install script (V4 or V5)
+├── myapp/                     # Hook scripts directory (V5 only, optional)
+│   └── myapp_hook.ts          # Hook implementation
+├── plex.json                  # Example: first-party V5 with hooks
+├── plex/
+│   └── plex_hook.ts
+├── jellyfin.json              # Example: V4 script (no hooks)
+└── ...
+```
+
+## Script Format
+
+- **V4**: Standard install scripts without hooks. Set `"version": 4`.
+- **V5**: Install scripts with lifecycle hooks. Set `"version": 5` and add a `hooks` array. See the [Hooks Reference](/features/apps/install-scripts/reference/hooks) for details.
+
+Both formats are fully supported. Use V5 only if your app benefits from post-install automation.
+
+## Using Inline Hooks (`scriptContent`)
+
+Community contributors who don't need separate `.ts` files can embed hook code directly in the JSON using the `scriptContent` field. This keeps everything in a single file:
+
+```json
+{
+  "version": 5,
+  "custom": true,
+  "metadata": { "name": "My App", "description": "...", "icon": "...", "version": "1.0.0" },
+  "hooks": [
+    {
+      "id": "health-check",
+      "event": "onAfterInstall",
+      "scriptContent": "export async function setup(ctx) {\n  await ctx.waitForApp('/health');\n  await ctx.emitCheckpoint('ready');\n}",
+      "entrypoint": "setup",
+      "timeout": 60,
+      "description": "Post-install health check",
+      "optional": true
+    }
+  ]
+}
+```
+
+::: tip Testing with Custom Install
+You can test inline hook scripts using **Custom Install in Expert Mode** — paste your V5 JSON with `scriptContent` hooks directly into the editor and run it. This is useful for development and testing before submitting a PR. Inline scripts should not be part of a PR submission for testing purposes only — submit them when they're ready for production use.
+:::
+
+## Best Practices
+
+- Use the [Schema Reference](/features/apps/install-scripts/reference/schema) and [Macros Reference](/features/apps/install-scripts/reference/macros) to understand all available fields and template variables
+- Browse existing scripts in the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) for real-world examples
+- Test thoroughly before submitting — both fresh installs and upgrades
+- Keep hooks focused and use `optional: true` for non-critical automation
+- Use `$LOCATION()` macros instead of hardcoded paths
+- Declare `owner` on directories that need specific permissions
+
+## Sharing Before Contributing
+
+Not ready for a PR? Share your install script JSON in the [HexOS Community Forums](https://forums.hexos.com) to get feedback from other users first.

--- a/docs/features/apps/install-scripts/curated/index.md
+++ b/docs/features/apps/install-scripts/curated/index.md
@@ -1,32 +1,17 @@
 # Apps (Curated Scripts)
 
-<!-- curated:index:start -->
-| App | Download | Size | Last Modified |
-|---|---|---:|---|
-| `bazarr` | [bazarr.json](/install-scripts/bazarr.json) | 1.4 KB | 2026-05-15 |
-| `blinko` | [blinko.json](/install-scripts/blinko.json) | 1.3 KB | 2026-05-20 |
-| `dozzle` | [dozzle.json](/install-scripts/dozzle.json) | 614 B | 2026-05-18 |
-| `drawio` | [drawio.json](/install-scripts/drawio.json) | 634 B | 2026-05-15 |
-| `emby` | [emby.json](/install-scripts/emby.json) | 2.3 KB | 2026-05-15 |
-| `excalidraw` | [excalidraw.json](/install-scripts/excalidraw.json) | 614 B | 2026-05-18 |
-| `fladder` | [fladder.json](/install-scripts/fladder.json) | 566 B | 2026-05-24 |
-| `handbrake` | [handbrake.json](/install-scripts/handbrake.json) | 1.9 KB | 2026-05-15 |
-| `home-assistant` | [home-assistant.json](/install-scripts/home-assistant.json) | 1.4 KB | 2026-05-15 |
-| `immich` | [immich.json](/install-scripts/immich.json) | 1.6 KB | 2026-05-15 |
-| `jellyfin` | [jellyfin.json](/install-scripts/jellyfin.json) | 2.3 KB | 2026-05-15 |
-| `jellystat` | [jellystat.json](/install-scripts/jellystat.json) | 1.6 KB | 2026-05-28 |
-| `lidarr` | [lidarr.json](/install-scripts/lidarr.json) | 1.4 KB | 2026-05-15 |
-| `lubelogger` | [lubelogger.json](/install-scripts/lubelogger.json) | 1.5 KB | 2026-05-18 |
-| `navidrome` | [navidrome.json](/install-scripts/navidrome.json) | 5.1 KB | 2026-05-18 |
-| `nextcloud` | [nextcloud.json](/install-scripts/nextcloud.json) | 3.4 KB | 2026-05-20 |
-| `peanut` | [peanut.json](/install-scripts/peanut.json) | 911 B | 2026-05-15 |
-| `plex` | [plex.json](/install-scripts/plex.json) | 3.4 KB | 2026-05-15 |
-| `portracker` | [portracker.json](/install-scripts/portracker.json) | 894 B | 2026-05-18 |
-| `prowlarr` | [prowlarr.json](/install-scripts/prowlarr.json) | 781 B | 2026-05-15 |
-| `qbittorrent` | [qbittorrent.json](/install-scripts/qbittorrent.json) | 1.0 KB | 2026-05-15 |
-| `radarr` | [radarr.json](/install-scripts/radarr.json) | 1.3 KB | 2026-05-15 |
-| `scrutiny` | [scrutiny.json](/install-scripts/scrutiny.json) | 1.4 KB | 2026-05-15 |
-| `seerr` | [seerr.json](/install-scripts/seerr.json) | 924 B | 2026-05-22 |
-| `sonarr` | [sonarr.json](/install-scripts/sonarr.json) | 1.3 KB | 2026-05-15 |
-| `syncthing` | [syncthing.json](/install-scripts/syncthing.json) | 2.6 KB | 2026-05-15 |
-<!-- curated:index:end -->
+Curated install scripts are maintained in the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository. This is the single source of truth — scripts are synced from this repo to HexOS automatically.
+
+::: info Repository Migration
+Install scripts have moved from this documentation site to the dedicated [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository. All contributions, bug fixes, and new scripts should be submitted there. See [Contributing](/features/apps/install-scripts/contributing) for details.
+:::
+
+## Browse Scripts
+
+**[Browse hexos-app-catalog on GitHub](https://github.com/eshtek/hexos-app-catalog)**
+
+Each `.json` file in the repository root is an install script. Apps with lifecycle hooks (V5) also have a subdirectory containing their hook `.ts` files (e.g., `plex/plex_hook.ts`).
+
+## Want to Contribute?
+
+See the [Contributing Guide](/features/apps/install-scripts/contributing) for how to submit your own install script to the catalog.

--- a/docs/features/apps/install-scripts/overview.md
+++ b/docs/features/apps/install-scripts/overview.md
@@ -9,6 +9,7 @@ Install scripts are a curated, turnkey solution for installing applications thro
 - **Best practices built-in** - All configurations follow recommended settings
 - **One-click installation** - Simplified installation process
 - **Curated experience** - Apps are pre-tested and optimized
+- **Post-install automation** - Lifecycle hooks can handle app setup after installation (V5)
 
 ### Current Capabilities
 - Configures all fields that TrueNAS exposes during app installation
@@ -16,9 +17,15 @@ Install scripts are a curated, turnkey solution for installing applications thro
 - Configures resource allocation (CPU, memory, GPU)
 - Sets up networking and port mappings
 - Manages storage mounts and paths
+- **Lifecycle hooks** — run automated setup steps before or after install and upgrade (V5)
 
-### Future Capabilities (Local UI)
-Once the Local UI feature is complete, these install scripts are able to do much more; ultimately bypassing any post-installation setup of these apps entirely. 
+### What's New in V5: Lifecycle Hooks
+
+V5 install scripts introduce **lifecycle hooks** — TypeScript functions that execute at specific points during app install and upgrade. Hooks enable post-install automation like health checks, service configuration, OAuth login, and more — all without the user needing to open the app's own UI.
+
+V5 is a strict superset of V4. The only new field is `hooks`. An existing V4 script can be promoted to V5 by changing `"version": 4` to `"version": 5` and optionally adding a `hooks` array.
+
+For full details, see the [Hooks Reference](/features/apps/install-scripts/reference/hooks).
 
 ## How to Use Install Scripts
 
@@ -34,6 +41,7 @@ For supported applications, the installation process is streamlined:
    - Allocate appropriate system resources
    - Mount required storage paths
    - Handle any app-specific requirements
+   - Run lifecycle hooks for post-install setup (V5 apps)
 
 ### Custom Installation
 For apps not yet curated or when you need to customize the configuration:
@@ -49,17 +57,21 @@ For apps not yet curated or when you need to customize the configuration:
 ### Best Practices and Common Pitfalls
 
 #### Best Practices
-- **Use V4 format** — all new install scripts must use `"version": 4`
+- **Use V5 format for new scripts with hooks**, or **V4 for scripts without hooks** — both are fully supported
 - **Always use `$LOCATION()` macros** for paths instead of hardcoded paths
 - **Use `$HOST_PATH()` and `$MOUNTED_HOST_PATH()`** for storage configuration instead of manual object creation
-- **All directory entries must be objects** — bare strings in `ensure_directories_exists` are no longer supported in V4
+- **All directory entries must be objects** — bare strings in `ensure_directories_exists` are no longer supported
 - **Declare ownership** with the `owner` field for apps that require specific user/group ownership (e.g., `"postgres"`, `"apps"`)
 - **Add `snapshot` config** on data and config directories to enable automatic pre-update ZFS snapshots
 - **Use `$MEMORY()` for dynamic memory allocation** to ensure apps work across different system configurations
 - **Reference TrueNAS app schemas** from the [official apps repository](https://github.com/truenas/apps) for `app_values` structure
+- **Keep hook scripts focused** — each hook should do one thing (health check, configuration, library setup)
+- **Use `optional: true`** on hooks that are nice-to-have but shouldn't block app installation if they fail
 
 #### Common Pitfalls
 - **Permission issues** are the most common cause of failures - both during installation and at runtime
 - **Hardcoded paths** break when users have custom location preferences
 - **Missing directory creation** can cause apps to fail during installation
 - **Incorrect `app_values` structure** for the specific TrueNAS app version
+- **Missing `await`** in hook scripts — all `ctx` methods are async and must be awaited
+- **Hook timeout too short** — apps can take 30-60 seconds to become responsive after container creation; use `ctx.waitForApp()` with appropriate timeouts

--- a/docs/features/apps/install-scripts/reference/hooks.md
+++ b/docs/features/apps/install-scripts/reference/hooks.md
@@ -1,0 +1,405 @@
+# Lifecycle Hooks Reference
+
+Lifecycle hooks are TypeScript functions that execute at specific points during app install and upgrade. They enable post-install automation like health checks, service configuration, OAuth login, library creation, and more.
+
+Hooks are a **V5** feature. To use hooks, set `"version": 5` in your install script and add a `hooks` array.
+
+## Hook Events
+
+| Event | When it fires |
+|---|---|
+| `onBeforeInstall` | Before `app.create` is called on TrueNAS |
+| `onAfterInstall` | After `app.create` completes successfully |
+| `onBeforeUpgrade` | Before `app.upgrade` is called on TrueNAS |
+| `onAfterUpgrade` | After `app.upgrade` completes successfully |
+
+## Hook Declaration
+
+Each entry in the `hooks` array is a hook declaration:
+
+```json
+{
+  "id": "setup-myapp",
+  "event": "onAfterInstall",
+  "script": "myapp/myapp_hook.ts",
+  "entrypoint": "afterInstall",
+  "timeout": 120,
+  "description": "Setting up MyApp",
+  "optional": false,
+  "retries": 1
+}
+```
+
+### Declaration Properties
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Unique identifier within the script |
+| `event` | string | Yes | One of the [hook events](#hook-events) above |
+| `script` | string | No | Path to a `.ts` file in the catalog repo (e.g., `"myapp/myapp_hook.ts"`) |
+| `scriptContent` | string | No | Inline TypeScript code embedded directly in the JSON |
+| `entrypoint` | string | Yes | Name of the exported async function to call |
+| `timeout` | number | No | Maximum execution time in seconds (default: 300) |
+| `description` | string | No | Human-readable label shown in the HexOS activity center |
+| `optional` | boolean | No | If `true`, hook failure is non-blocking — the app install continues |
+| `retries` | number | No | Number of automatic retry attempts on failure (default: 0) |
+| `condition` | object | No | Version-based guards for upgrade hooks (see [Conditions](#version-conditions)) |
+| `inputs` | array | No | OAuth or question inputs to collect from the user before execution (see [Inputs](#hook-inputs)) |
+| `userOptional` | object | No | Allows the user to opt out of this hook during install (see [User Optional](#user-optional-hooks)) |
+
+::: warning script vs scriptContent
+Every hook must have exactly one of `script` or `scriptContent` — never both, never neither. The schema enforces this with a validation rule.
+
+- **`script`** — references an external `.ts` file in the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repo. Used by first-party curated hooks.
+- **`scriptContent`** — embeds the TypeScript code directly in the JSON. Used by community contributions for self-contained simplicity.
+:::
+
+## Writing a Hook Script
+
+Hook scripts are TypeScript files that export an async function. The function receives a `HookContext` object with methods for interacting with the app and reporting progress.
+
+### File-Based Hook (first-party)
+
+Create a directory for your app in the catalog repo with a `.ts` file:
+
+```
+hexos-app-catalog/
+├── myapp/
+│   └── myapp_hook.ts
+└── myapp.json
+```
+
+```typescript
+// myapp/myapp_hook.ts
+import type { HookContext } from "../_lib/hook_context";
+
+export async function afterInstall(ctx: HookContext) {
+  await ctx.registerCheckpoints([
+    { id: "ready", message: "Waiting for app to start" },
+    { id: "configured", message: "Configuring app" },
+  ]);
+
+  await ctx.waitForApp("/health");
+  await ctx.emitCheckpoint("ready");
+
+  // Do configuration via the app's API...
+  await ctx.emitCheckpoint("configured");
+}
+```
+
+Reference it in the install script JSON:
+
+```json
+{
+  "version": 5,
+  "hooks": [
+    {
+      "id": "configure-myapp",
+      "event": "onAfterInstall",
+      "script": "myapp/myapp_hook.ts",
+      "entrypoint": "afterInstall",
+      "timeout": 120,
+      "description": "Setting up MyApp"
+    }
+  ]
+}
+```
+
+### Inline Hook (community `scriptContent`)
+
+Embed the code directly in the JSON — no external files needed:
+
+```json
+{
+  "version": 5,
+  "custom": true,
+  "metadata": {
+    "name": "My App",
+    "description": "A custom community app",
+    "icon": "https://example.com/icon.svg",
+    "version": "1.0.0"
+  },
+  "hooks": [
+    {
+      "id": "health-check",
+      "event": "onAfterInstall",
+      "scriptContent": "export async function setup(ctx) {\n  await ctx.waitForApp('/health');\n  ctx.log('App is ready');\n  await ctx.emitCheckpoint('ready');\n}",
+      "entrypoint": "setup",
+      "timeout": 60,
+      "description": "Post-install health check"
+    }
+  ]
+}
+```
+
+::: tip Testing inline hooks
+The `scriptContent` field is useful for **testing hooks via Custom Install in Expert Mode** — you can paste a V5 JSON with inline hooks directly into the editor and run it immediately. This is a development and testing workflow only; inline scripts submitted via PR go through the same review process as file-based hooks.
+:::
+
+## HookContext API
+
+The `HookContext` object is passed to your hook function. It provides everything needed to interact with the installed app, report progress, and handle errors.
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `resourceType` | `string` | Always `"app"` (future: `"vm"`, etc.) |
+| `resourceId` | `string` | The app ID (e.g., `"plex"`) |
+| `event` | `string` | The triggering event (e.g., `"onAfterInstall"`) |
+| `fromVersion` | `string?` | Previous app version (upgrade only) |
+| `toVersion` | `string?` | Target app version (upgrade only) |
+| `host` | `string?` | TrueNAS LAN IP address |
+| `port` | `number?` | App's primary exposed port |
+| `baseUrl` | `string` | `http://{host}:{port}` — empty string if unavailable |
+| `inputs` | `Record<string, unknown>` | User-collected input values from [hook inputs](#hook-inputs) |
+
+### Methods
+
+#### Checkpoint Management
+
+Checkpoints represent progress steps shown to the user in the HexOS activity center.
+
+| Method | Description |
+|---|---|
+| `registerCheckpoints(checkpoints)` | Register all checkpoints upfront for UI display. Each checkpoint has `{ id, message }`. |
+| `emitCheckpoint(id, message?, progress?)` | Mark a checkpoint as completed. Optionally update its message and set a progress percentage. |
+| `updateCheckpointMessage(id, message)` | Update a checkpoint's message without completing it. |
+| `skipCheckpoint(id, message?)` | Mark a checkpoint as skipped. |
+
+#### Utilities
+
+| Method | Description |
+|---|---|
+| `log(message)` | Log a message to the backend logger (not shown to the user). |
+| `sleep(ms)` | Async delay for the given number of milliseconds. |
+| `waitForApp(path, opts?)` | Poll the app's HTTP endpoint until it responds. Uses exponential backoff (40 attempts by default). Options: `{ timeout?, retries?, method?, expectedStatus? }` |
+
+#### Error Handling
+
+| Method | Description |
+|---|---|
+| `fail(message, context?)` | Throw a structured error. `context` is an array of `{ label, value }` pairs for diagnostic display. |
+| `awaitCheckpointRetry(checkpointId, error, context?)` | Pause the hook at a failed checkpoint and wait for the user to click Retry or Skip. Returns `"retry"` or `"skip"`. |
+
+#### Input Access
+
+| Method | Description |
+|---|---|
+| `getInput<T>(inputId, schema?)` | Type-safe accessor for user-collected inputs. Throws if the input is missing. |
+
+## Version Conditions
+
+Hooks can be restricted to specific version transitions during upgrades:
+
+```json
+{
+  "id": "migrate-config",
+  "event": "onBeforeUpgrade",
+  "condition": {
+    "fromVersionRange": "< 2.0.0",
+    "toVersionRange": ">= 2.0.0"
+  },
+  "script": "myapp/migrate.ts",
+  "entrypoint": "migrateConfig",
+  "description": "Migrating config for v2"
+}
+```
+
+Both `fromVersionRange` and `toVersionRange` use [semver range syntax](https://www.npmjs.com/package/semver#ranges). The hook only fires if both conditions match (when both are specified).
+
+## Hook Inputs
+
+Hooks can declare inputs that are collected from the user before the hook runs. The HexOS UI shows an input dialog when the hook enters the `AWAITING_INPUT` state.
+
+### OAuth Input
+
+```json
+{
+  "inputs": [
+    {
+      "type": "oauth",
+      "id": "plex_login",
+      "name": "Sign in to Plex",
+      "description": "Required for server claim and library setup",
+      "provider": "plex",
+      "flow": {
+        "type": "pin",
+        "pinUrl": "https://plex.tv/api/v2/pins",
+        "authUrl": "https://app.plex.tv/auth#?clientID={clientId}&code={code}",
+        "pollUrl": "https://plex.tv/api/v2/pins/{pinId}",
+        "clientId": "your-client-id",
+        "tokenField": "authToken",
+        "headers": { "Accept": "application/json" }
+      }
+    }
+  ]
+}
+```
+
+### Question Input
+
+```json
+{
+  "inputs": [
+    {
+      "type": "question",
+      "id": "library_name",
+      "question": {
+        "question": "Library Name",
+        "description": "Name for the media library to create",
+        "type": "text",
+        "key": "library_name",
+        "default": "Movies"
+      }
+    }
+  ]
+}
+```
+
+Access input values in your hook script:
+
+```typescript
+const { authToken } = ctx.getInput<{ authToken: string }>("plex_login");
+const libraryName = ctx.getInput<string>("library_name");
+```
+
+## User Optional Hooks
+
+Hooks with `userOptional` show a checkbox in the install dialog, letting the user decide whether to run the hook:
+
+```json
+{
+  "id": "auto-setup",
+  "event": "onAfterInstall",
+  "userOptional": {
+    "label": "Automatically configure MyApp",
+    "description": "Signs in and sets up your libraries. You can do this manually later.",
+    "default": true
+  }
+}
+```
+
+During upgrades, `userOptional` hooks are automatically excluded — only non-optional hooks run.
+
+## Hook Execution Flow
+
+### Install
+
+1. User confirms install (with optional hook opt-ins)
+2. `onBeforeInstall` hooks run sequentially (blocks app creation)
+3. TrueNAS `app.create` executes
+4. `onAfterInstall` hooks run sequentially (blocks task completion)
+5. Parent install task completes when all required hooks finish
+
+### Upgrade
+
+Same pattern with `onBeforeUpgrade` and `onAfterUpgrade`. Only hooks matching the version [conditions](#version-conditions) run. `userOptional` hooks are excluded.
+
+### Failure Handling
+
+When a non-optional hook fails after all auto-retries:
+
+1. The hook task enters `AWAITING_RETRY` state
+2. The user sees Retry and Skip buttons in the activity center
+3. **Retry** re-executes the hook from the beginning (or from the failed checkpoint if using `awaitCheckpointRetry`)
+4. **Skip** marks the hook as skipped and allows the parent task to complete
+
+Optional hooks (`optional: true`) are automatically skipped on failure without blocking the install.
+
+## Checkpoint Retry Pattern
+
+For hooks with multiple steps, use `awaitCheckpointRetry` to let users retry individual steps without restarting the entire hook:
+
+```typescript
+export async function afterInstall(ctx: HookContext) {
+  await ctx.registerCheckpoints([
+    { id: "movies", message: "Creating Movies library" },
+    { id: "shows", message: "Creating Shows library" },
+  ]);
+
+  // Create Movies library
+  try {
+    await createLibrary("Movies");
+    await ctx.emitCheckpoint("movies");
+  } catch (err) {
+    const action = await ctx.awaitCheckpointRetry("movies", err.message, [
+      { label: "Endpoint", value: "POST /library/sections" },
+      { label: "Status", value: err.status },
+    ]);
+    if (action === "skip") {
+      await ctx.skipCheckpoint("movies", "Skipped by user");
+    } else {
+      // Retry logic...
+    }
+  }
+}
+```
+
+## Custom App Metadata
+
+When `custom: true`, the `metadata` field is required:
+
+```json
+{
+  "version": 5,
+  "custom": true,
+  "metadata": {
+    "name": "My Custom App",
+    "description": "A brief description of what the app does",
+    "icon": "https://example.com/icon.svg",
+    "version": "1.0.0"
+  }
+}
+```
+
+Custom apps appear in the HexOS app store alongside standard TrueNAS catalog apps. The `internal: true` flag hides them in production (useful for test apps).
+
+## Complete V5 Example
+
+```json
+{
+  "version": 5,
+  "script": {
+    "version": "1.0.0",
+    "changeLog": "Initial release with post-install health check"
+  },
+  "requirements": {
+    "locations": ["ApplicationsPerformance"],
+    "specifications": ["1CORE", "200MB"],
+    "permissions": ["READ_WRITE_LOCATIONS"],
+    "ports": [8080]
+  },
+  "ensure_directories_exists": [
+    {
+      "path": "$LOCATION(ApplicationsPerformance)/myapp/config",
+      "owner": { "user": "apps" },
+      "snapshot": { "id": "config" }
+    }
+  ],
+  "app_values": {
+    "storage": {
+      "config": "$HOST_PATH($LOCATION(ApplicationsPerformance)/myapp/config)"
+    },
+    "network": {
+      "web_port": { "port_number": 8080 }
+    },
+    "resources": {
+      "limits": {
+        "memory": "$MEMORY(5%, 200)"
+      }
+    }
+  },
+  "hooks": [
+    {
+      "id": "health-check",
+      "event": "onAfterInstall",
+      "scriptContent": "export async function afterInstall(ctx) {\n  await ctx.registerCheckpoints([\n    { id: 'ready', message: 'Waiting for app' }\n  ]);\n  await ctx.waitForApp('/health');\n  await ctx.emitCheckpoint('ready');\n}",
+      "entrypoint": "afterInstall",
+      "timeout": 120,
+      "description": "Checking app health",
+      "optional": true
+    }
+  ]
+}
+```

--- a/docs/features/apps/install-scripts/reference/hooks.md
+++ b/docs/features/apps/install-scripts/reference/hooks.md
@@ -266,7 +266,7 @@ const libraryName = ctx.getInput<string>("library_name");
 
 ## User Optional Hooks
 
-Hooks with `userOptional` show a checkbox in the install dialog, letting the user decide whether to run the hook:
+Hooks with `userOptional` show a toggle switch in the install dialog, letting the user decide whether to run the hook:
 
 ```json
 {
@@ -279,6 +279,46 @@ Hooks with `userOptional` show a checkbox in the install dialog, letting the use
   }
 }
 ```
+
+### userOptional Properties
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `label` | string | Yes | Short label displayed next to the toggle switch |
+| `description` | string | No | Explanatory text shown below the toggle |
+| `default` | boolean | No | Whether the toggle is on by default (default: `true`) |
+| `link` | object | No | A link rendered inline at the end of the description (see below) |
+
+### Adding a Link
+
+Use the `link` property to display a clickable link after the description text. This is useful when your hook performs an action that requires the user to acknowledge external terms of service or documentation.
+
+```json
+{
+  "id": "configure-plex",
+  "event": "onAfterInstall",
+  "userOptional": {
+    "label": "Pre-configure Plex",
+    "description": "Sign in to your Plex account to automatically claim your server, set preferences, and create media libraries. By enabling this, you agree that HexOS will accept the Plex Terms of Service on your behalf.",
+    "default": true,
+    "link": {
+      "url": "https://www.plex.tv/about/privacy-legal/plex-terms-of-service/",
+      "label": "Plex Terms of Service"
+    }
+  }
+}
+```
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `link.url` | string | Yes | Fully qualified URL (must pass URL validation) |
+| `link.label` | string | Yes | Clickable text displayed as the link |
+
+The link opens in a new tab. It renders inline at the end of the description paragraph, styled as a branded underlined link.
+
+::: tip When to use a link
+If your hook accepts terms, agrees to a EULA, or performs an action governed by a third-party service's policies on behalf of the user, include a `link` to the relevant terms so the user can review them before opting in.
+:::
 
 During upgrades, `userOptional` hooks are automatically excluded — only non-optional hooks run.
 

--- a/docs/features/apps/install-scripts/reference/schema.md
+++ b/docs/features/apps/install-scripts/reference/schema.md
@@ -2,9 +2,16 @@
 
 Install scripts are JSON objects with the following structure. Scripts can use various macros (template variables) that are dynamically replaced during processing.
 
+::: tip Source of Truth
+Install scripts live in the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository. See [Contributing](/features/apps/install-scripts/contributing) for how to submit new scripts.
+:::
+
 ## Root Properties
 
-- **`version`** (required): Schema version. Must be `4` (current required version). Versions 1-3 are deprecated.
+- **`version`** (required): Schema version. Must be `4` or `5`. Versions 1-3 are deprecated. Use `5` if your script includes lifecycle hooks; otherwise `4` is fine.
+- **`custom`** (optional): Set to `true` for community/custom apps that aren't in the default TrueNAS catalog
+- **`internal`** (optional): Set to `true` for dev/test apps — hidden in production
+- **`metadata`** (required if `custom: true`): Custom app metadata (see [Custom App Metadata](#custom-app-metadata))
 - **`script`** (required): Metadata about the install script itself
   - **`version`** (required): Semantic version of this install script (e.g., "1.0.0", "2.1.3")
   - **`updateCompatibility`** (optional): Semver range expression defining which script versions can update to this version (e.g., ">=1.0.0" allows updates from any version 1.0.0 or higher, "^2.0.0" allows updates from 2.x.x versions). Supports all [semver range syntax](https://www.npmjs.com/package/semver#ranges) including `>=`, `>`, `<`, `<=`, `^`, `~`, and complex ranges like `">=1.0.0 <3.0.0"`
@@ -13,6 +20,7 @@ Install scripts are JSON objects with the following structure. Scripts can use v
 - **`installation_questions`** (optional): Array of questions to ask the user during installation
 - **`ensure_directories_exists`** (optional): Array of directory entry objects to create before installation, with optional ownership and snapshot declarations
 - **`app_values`** (required): Configuration object passed directly to TrueNAS API
+- **`hooks`** (optional, V5 only): Array of lifecycle hook declarations. See [Hooks Reference](/features/apps/install-scripts/reference/hooks)
 
 ## Available Macros
 
@@ -42,9 +50,20 @@ Install scripts support various macros that are replaced dynamically during scri
 
 For detailed macro documentation and examples, see the [Macros Reference](/features/apps/install-scripts/reference/macros).
 
+## Custom App Metadata
+
+When `custom: true`, the `metadata` object is required:
+
+| Property | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Display name in the HexOS app store |
+| `description` | string | Yes | Brief description of what the app does |
+| `icon` | string | Yes | URL to the app's icon (SVG or PNG) |
+| `version` | string | Yes | Semantic version of the custom app |
+
 ## Example Structure
 
-For complete, working examples of install scripts, please refer to the [curated install scripts](/features/apps/install-scripts/curated/). These production-ready scripts demonstrate best practices and real-world usage patterns for popular applications like Plex, Jellyfin, Immich, and more.
+For complete, working examples of install scripts, browse the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository. These production-ready scripts demonstrate best practices and real-world usage patterns for popular applications like Plex, Jellyfin, Immich, and more.
 
 ## Requirements
 

--- a/package.json
+++ b/package.json
@@ -4,19 +4,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "gen:curated": "node scripts/generateCuratedIndex.mjs",
     "gen:release-notes": "node scripts/generateReleaseNotesIndex.mjs",
-    "gen:all": "npm run gen:curated && npm run gen:release-notes",
+    "gen:all": "npm run gen:release-notes",
     "docs:dev": "npm run gen:all && vitepress dev docs",
     "dev": "npm run docs:dev",
-    "docs:dev:here": "DOCS_DIR=. node scripts/generateCuratedIndex.mjs && node scripts/generateReleaseNotesIndex.mjs && vitepress dev .",
+    "docs:dev:here": "node scripts/generateReleaseNotesIndex.mjs && vitepress dev .",
     "docs:build": "npm run gen:all && vitepress build docs",
     "docs:serve": "vitepress serve docs",
-    "build": "npm run docs:build",
-    "prepare": "husky"
+    "build": "npm run docs:build"
   },
   "devDependencies": {
-    "husky": "^9.1.7",
     "mermaid": "^11.10.0",
     "vitepress": "^1.3.0",
     "vitepress-plugin-mermaid": "^2.0.17"

--- a/scripts/generateCuratedIndex.mjs
+++ b/scripts/generateCuratedIndex.mjs
@@ -7,8 +7,8 @@ import { execSync } from 'child_process'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const DOCS_DIR = process.env.DOCS_DIR || 'docs'
 
-const PUBLIC_DIR = path.resolve(__dirname, '..', DOCS_DIR, 'public', 'install-scripts')
-const APPS_MD   = path.resolve(__dirname, '..', DOCS_DIR, 'features/apps/install-scripts/curated', 'index.md')
+const CATALOG_DIR = process.env.CATALOG_DIR || path.resolve(__dirname, '..', '..', 'hexos-app-catalog')
+const APPS_MD = path.resolve(__dirname, '..', DOCS_DIR, 'features/apps/install-scripts/curated', 'index.md')
 
 const START = '<!-- curated:index:start -->'
 const END   = '<!-- curated:index:end -->'
@@ -24,21 +24,19 @@ function humanFileSize(bytes) {
 
 function getGitLastModified(filePath) {
   try {
-    // Get the last commit date for the specific file
     const gitCommand = `git log -1 --format=%ci "${filePath}"`
-    const result = execSync(gitCommand, { 
-      cwd: path.dirname(filePath), 
-      encoding: 'utf8' 
+    const result = execSync(gitCommand, {
+      cwd: path.dirname(filePath),
+      encoding: 'utf8'
     }).trim()
-    
+
     if (result) {
       return new Date(result).toISOString().split('T')[0]
     }
   } catch (error) {
     console.warn(`Could not get git date for ${filePath}, falling back to fs date`)
   }
-  
-  // Fallback to filesystem date if git fails
+
   try {
     const stat = fs.statSync(filePath)
     return new Date(stat.mtime).toISOString().split('T')[0]
@@ -47,18 +45,47 @@ function getGitLastModified(filePath) {
   }
 }
 
+function getScriptVersion(filePath) {
+  try {
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return content.version || '?'
+  } catch {
+    return '?'
+  }
+}
+
+function hasHooks(filePath) {
+  try {
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return Array.isArray(content.hooks) && content.hooks.length > 0
+  } catch {
+    return false
+  }
+}
+
+function isInternalApp(filePath) {
+  try {
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    return content.internal === true
+  } catch {
+    return false
+  }
+}
+
 function buildTable(files) {
   const lines = []
-  lines.push('| App | Download | Size | Last Modified |')
-  lines.push('|---|---|---:|---|')
+  lines.push('| App | Format | Hooks | Size | Last Modified |')
+  lines.push('|---|---|---|---:|---|')
   for (const file of files) {
-    const p = path.join(PUBLIC_DIR, file)
+    const p = path.join(CATALOG_DIR, file)
     const stat = fs.statSync(p)
     const size = humanFileSize(stat.size)
     const mtime = getGitLastModified(p)
     const app = path.basename(file, '.json')
-    const href = `/install-scripts/${file}`
-    lines.push(`| \`${app}\` | [${file}](${href}) | ${size} | ${mtime} |`)
+    const version = `V${getScriptVersion(p)}`
+    const hooks = hasHooks(p) ? 'Yes' : '—'
+    const href = `https://github.com/eshtek/hexos-app-catalog/blob/main/${file}`
+    lines.push(`| [\`${app}\`](${href}) | ${version} | ${hooks} | ${size} | ${mtime} |`)
   }
   return lines.join('\n')
 }
@@ -68,6 +95,8 @@ function ensureAppsPage() {
     fs.mkdirSync(path.dirname(APPS_MD), { recursive: true })
     const boilerplate =
 `# Apps (Curated Scripts)
+
+Curated install scripts are maintained in the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repository.
 
 ${START}
 _No curated scripts yet._
@@ -79,18 +108,29 @@ ${END}
 
 function updateAppsPage() {
   ensureAppsPage()
+
+  if (!fs.existsSync(CATALOG_DIR)) {
+    console.error(`Catalog directory not found: ${CATALOG_DIR}`)
+    console.error('Clone hexos-app-catalog as a sibling directory or set CATALOG_DIR env var')
+    process.exit(1)
+  }
+
   let md = fs.readFileSync(APPS_MD, 'utf8')
 
   if (!md.includes(START) || !md.includes(END)) {
-    // If markers missing, append a fresh block to the end
     md += `\n\n${START}\n${END}\n`
   }
 
-  fs.mkdirSync(PUBLIC_DIR, { recursive: true })
-  const files = fs.readdirSync(PUBLIC_DIR).filter(f => f.endsWith('.json')).sort()
+  const files = fs.readdirSync(CATALOG_DIR)
+    .filter(f => f.endsWith('.json'))
+    .filter(f => {
+      const p = path.join(CATALOG_DIR, f)
+      return !isInternalApp(p)
+    })
+    .sort()
 
   const content = files.length === 0
-    ? '_No curated scripts found yet — add JSON files under `docs/public/install-scripts/` and run `npm run gen:curated`._'
+    ? '_No curated scripts found — add JSON files to the [hexos-app-catalog](https://github.com/eshtek/hexos-app-catalog) repo._'
     : buildTable(files)
 
   const before = md.slice(0, md.indexOf(START) + START.length)


### PR DESCRIPTION
This release adds support for V5 install scripts, which include lifecycle hooks for advanced post-installation automation. These hooks allow for features like health checks, service configuration, and OAuth login directly within the installation workflow.

The source of truth for curated install scripts has been migrated to a dedicated `hexos-app-catalog` repository. This refactors the contribution workflow and simplifies the documentation build process by removing internal script generation.

Documentation has been updated to reflect:
- Comprehensive reference for V5 hooks and their API.
- New debugging guidelines for hook failures.
- Revised contribution process for the new app catalog.
- Updated schema reference for V5 properties and custom app metadata.
